### PR TITLE
refactor: prevent race condition at update listing

### DIFF
--- a/src/server/featured-listings/service.ts
+++ b/src/server/featured-listings/service.ts
@@ -136,42 +136,46 @@ export async function updateFeaturedListingForRealtor(
   listing: FeaturedListing;
   previousImageUrl: string | null;
 } | null> {
-  const existingListing = await db.query.featuredListing.findFirst({
-    where: and(
-      eq(featuredListing.id, id),
-      eq(featuredListing.realtorId, realtorId),
-    ),
+  const listingOwnershipFilter = and(
+    eq(featuredListing.id, id),
+    eq(featuredListing.realtorId, realtorId),
+  );
+
+  return db.transaction(async (tx) => {
+    const [lockedListing] = await tx
+      .select()
+      .from(featuredListing)
+      .where(listingOwnershipFilter)
+      .for("update");
+
+    if (!lockedListing) {
+      return null;
+    }
+
+    const [updatedListing] = await tx
+      .update(featuredListing)
+      .set({
+        ...input,
+        updatedAt: new Date(),
+      })
+      .where(listingOwnershipFilter)
+      .returning();
+
+    if (!updatedListing) {
+      return null;
+    }
+
+    // Capture previous image URL under the same row lock to avoid stale cleanup targets.
+    const previousImageUrl =
+      input.imageUrl !== undefined && input.imageUrl !== lockedListing.imageUrl
+        ? lockedListing.imageUrl
+        : null;
+
+    return {
+      listing: toFeaturedListing(updatedListing),
+      previousImageUrl,
+    };
   });
-
-  if (!existingListing) {
-    return null;
-  }
-
-  const [updatedListing] = await db
-    .update(featuredListing)
-    .set({
-      ...input,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(eq(featuredListing.id, id), eq(featuredListing.realtorId, realtorId)),
-    )
-    .returning();
-
-  if (!updatedListing) {
-    return null;
-  }
-
-  // Track previous image URL if a new one was provided and differs from existing
-  const previousImageUrl =
-    input.imageUrl !== undefined && input.imageUrl !== existingListing.imageUrl
-      ? existingListing.imageUrl
-      : null;
-
-  return {
-    listing: toFeaturedListing(updatedListing),
-    previousImageUrl,
-  };
 }
 
 /**


### PR DESCRIPTION
This pull request refactors the `updateFeaturedListingForRealtor` function in `service.ts` to improve data consistency and prevent race conditions by using a database transaction with row-level locking. The function now ensures that the update and retrieval of the previous image URL happen atomically, reducing the risk of stale data during concurrent updates.

**Database transaction and consistency improvements:**

* Refactored the update logic to run inside a database transaction, using `.for("update")` to acquire a row-level lock on the targeted listing, ensuring atomicity and preventing race conditions during updates.
* The previous image URL is now captured after acquiring the lock, guaranteeing that it reflects the most up-to-date value and avoiding stale cleanup targets.