### PR TITLE
refactor: configured better-auth ip address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@
 # Better Auth
 BETTER_AUTH_API_KEY=
 
+# Proxy trust controls for Better Auth IP resolution/rate limiting.
+# Set TRUSTED_PROXY_ENV only when traffic is always behind that provider.
+# Allowed values: "vercel" | "cloudflare"
+TRUSTED_PROXY_ENV=
+# Optional comma-separated header override, e.g.:
+# IP_ADDRESS_HEADERS="x-vercel-forwarded-for,x-forwarded-for"
+IP_ADDRESS_HEADERS=
+
 # Secret used by Better Auth
 BETTER_AUTH_SECRET=""
 

--- a/src/env.js
+++ b/src/env.js
@@ -9,6 +9,8 @@ export const env = createEnv({
 	server: {
 		BETTER_AUTH_API_KEY: z.string().optional(),
 		BETTER_AUTH_URL: z.string(),
+		TRUSTED_PROXY_ENV: z.enum(["vercel", "cloudflare"]).optional(),
+		IP_ADDRESS_HEADERS: z.string().optional(),
 		BETTER_AUTH_SECRET: process.env.NODE_ENV === "production" ? z.string() : z.string().optional(),
 		BETTER_AUTH_GITHUB_CLIENT_ID: z.string().optional(),
 		BETTER_AUTH_GITHUB_CLIENT_SECRET: z.string().optional(),
@@ -41,6 +43,8 @@ export const env = createEnv({
 	runtimeEnv: {
 		BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
 		BETTER_AUTH_API_KEY: process.env.BETTER_AUTH_API_KEY,
+		TRUSTED_PROXY_ENV: process.env.TRUSTED_PROXY_ENV,
+		IP_ADDRESS_HEADERS: process.env.IP_ADDRESS_HEADERS,
 		BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
 		BETTER_AUTH_GITHUB_CLIENT_ID: process.env.BETTER_AUTH_GITHUB_CLIENT_ID,
 		BETTER_AUTH_GITHUB_CLIENT_SECRET: process.env.BETTER_AUTH_GITHUB_CLIENT_SECRET,

--- a/src/server/better-auth/config.ts
+++ b/src/server/better-auth/config.ts
@@ -6,6 +6,63 @@ import {env} from "@/env";
 import {db} from "@/server/db";
 import {buildSocialProviders} from "@/server/better-auth/social-providers";
 
+const VERCEL_IP_ADDRESS_HEADERS = ["x-vercel-forwarded-for", "x-forwarded-for"] as const;
+const CLOUDFLARE_IP_ADDRESS_HEADERS = ["cf-connecting-ip", "x-forwarded-for"] as const;
+
+function parseIpAddressHeaders(value: string | undefined) {
+	if (!value) {
+		return undefined;
+	}
+
+	const headers = value
+		.split(",")
+		.map((header: string) => header.trim())
+		.filter(Boolean);
+
+	return headers.length > 0 ? headers : undefined;
+}
+
+function getTrustedProxyPlatform() {
+	if (env.TRUSTED_PROXY_ENV) {
+		return env.TRUSTED_PROXY_ENV;
+	}
+
+	if (process.env.VERCEL === "1") {
+		return "vercel" as const;
+	}
+
+	if (process.env.CF_PAGES === "1" || process.env.CF_WORKER === "1") {
+		return "cloudflare" as const;
+	}
+
+	return undefined;
+}
+
+function getIpAddressHeaders() {
+	const platform = getTrustedProxyPlatform();
+
+	if (!platform) {
+		// Untrusted environments should not trust forwarding headers from clients.
+		return [];
+	}
+
+	const configuredHeaders = parseIpAddressHeaders(env.IP_ADDRESS_HEADERS);
+
+	if (configuredHeaders) {
+		return configuredHeaders;
+	}
+
+	if (platform === "vercel") {
+		return [...VERCEL_IP_ADDRESS_HEADERS];
+	}
+
+	if (platform === "cloudflare") {
+		return [...CLOUDFLARE_IP_ADDRESS_HEADERS];
+	}
+
+	return [];
+}
+
 function getAuthOptions(): BetterAuthOptions {
 	return {
 		baseURL: env.BETTER_AUTH_URL,
@@ -19,15 +76,7 @@ function getAuthOptions(): BetterAuthOptions {
 		plugins: [...(env.BETTER_AUTH_API_KEY ? [dash({apiKey: env.BETTER_AUTH_API_KEY})] : [])],
 		advanced: {
 			ipAddress: {
-				/**
-				 * Headers checked in order of priority to resolve the real client IP
-				 * behind reverse proxies. Covers Vercel and Cloudflare deployments.
-				 *
-				 * - x-vercel-forwarded-for  : set by Vercel's edge network
-				 * - cf-connecting-ip        : set by Cloudflare's proxy
-				 * - x-forwarded-for         : standard proxy header (fallback)
-				 */
-				ipAddressHeaders: ["x-vercel-forwarded-for", "cf-connecting-ip", "x-forwarded-for"],
+				ipAddressHeaders: getIpAddressHeaders(),
 			},
 		},
 		user: {


### PR DESCRIPTION
This pull request adds an advanced configuration option to the authentication system to improve how the real client IP address is determined, especially when deployed behind reverse proxies like Vercel and Cloudflare.

**Authentication configuration improvements:**

* Added an `advanced.ipAddress` option to the `getAuthOptions` function in `src/server/better-auth/config.ts`, specifying the order of HTTP headers (`x-vercel-forwarded-for`, `cf-connecting-ip`, `x-forwarded-for`) to check for the client's real IP address behind proxies.