### PR TITLE
refactor: gemini recommendations x2

### DIFF
--- a/src/server/better-auth/config.ts
+++ b/src/server/better-auth/config.ts
@@ -54,13 +54,9 @@ function getIpAddressHeaders() {
 
 	if (platform === "vercel") {
 		return [...VERCEL_IP_ADDRESS_HEADERS];
-	}
-
-	if (platform === "cloudflare") {
+	} else {
 		return [...CLOUDFLARE_IP_ADDRESS_HEADERS];
 	}
-
-	return [];
 }
 
 function getAuthOptions(): BetterAuthOptions {


### PR DESCRIPTION
This pull request simplifies the logic in the `getIpAddressHeaders` function in `src/server/better-auth/config.ts` by consolidating the platform checks and ensuring the correct set of headers is returned for both "vercel" and "cloudflare" platforms.

Refactor of IP address header selection logic:

* Simplified the conditional logic in `getIpAddressHeaders` to use an `else` block, ensuring that if the platform is not "vercel", it defaults to returning Cloudflare headers. This change removes unreachable code and makes the intent clearer.