### PR TITLE
add: privacy page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,9 +10,8 @@ export default function NotFound() {
 				<div className="space-y-2">
 					<h1 className="text-foreground/20 text-8xl font-bold tracking-tighter">404</h1>
 					<h2 className="text-3xl font-bold tracking-tight sm:text-4xl">Page not found</h2>
-					<p className="text-muted-foreground text-lg">Sorry, we couldn&apos;t find the page you&apos;re looking for. It might have been removed, renamed, or doesn&apos;t exist.</p>
-				</div>
-
+					<p className="text-muted-foreground text-lg">Sorry, we couldn&apos;t find the page you&apos;re looking for. It might have been removed, renamed, or doesn&apos;t exist.</p>{" "}
+				</div>{" "}
 				<div className="flex flex-col items-center justify-center gap-4 pt-6 sm:flex-row">
 					<Link
 						href="/"
@@ -28,7 +27,7 @@ export default function NotFound() {
 						Back to Home
 					</Link>
 					<Link
-						href="/listings"
+						href="listings"
 						className={cn(
 							buttonVariants({
 								variant: "outline",

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,208 @@
+import HashReset from "@/utils/HashReset";
+
+export const metadata = {
+	title: "Privacy Policy, Terms & Conditions - Vince Villanueva Real Estate",
+	description: "Privacy Policy, Terms and Conditions, and Disclaimer for Vince Villanueva Real Estate.",
+};
+
+export default function PrivacyPage() {
+	return (
+		<>
+			<HashReset />
+			<main className="container mx-auto max-w-4xl px-4 py-12 md:py-24">
+				<div className="space-y-6 text-base leading-relaxed text-zinc-700 dark:text-zinc-300">
+					<h1 className="mb-8 text-3xl font-bold tracking-tighter text-zinc-900 sm:text-4xl md:text-5xl dark:text-zinc-50">PRIVACY POLICY</h1>
+
+					<p>
+						This privacy policy has been compiled to better serve those who are concerned with how their &apos;Personally identifiable information&apos; (PII) is being used online. We understand the power that the Internet holds for
+						changing your life and making things easier for you. These benefits are at risk if people are concerned about their personal privacy. We are committed to providing you with an Internet experience that respects and protects
+						your personal privacy choices and concerns. In general, we gather information about all of our users collectively. We only use such information anonymously and in the aggregate. This information helps us determine what is most
+						beneficial for our users, and how we can continually create a better overall experience for you. Please read our privacy policy carefully to get a clear understanding of how we collect, use, protect or otherwise handle your
+						Personally Identifiable Information in accordance with our website.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Personal Information</h2>
+					<p>
+						This website functionality requires/requests users to provide contact information (such as their email address) and personal information (such as their names, address phone numbers, and property details). The user&apos;s
+						contact and personal information is used to contact said user when necessary and requested, but is primarily used to collect personal information necessary to effectively market and to sell the property of sellers, to locate,
+						assess and qualify properties for buyers and to otherwise provide professional services to clients and customers.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Information Collection and Use</h2>
+					<p>
+						When subscribing to a newsletter or filling out a form, as appropriate, we collect the information you enter, including but not limited to, your name, email address, mailing address, phone number or other details to help you
+						with your experience.
+					</p>
+					<p>We may use the information we collect from you in the following ways:</p>
+					<ul className="mb-4 ml-6 list-disc space-y-2">
+						<li>To personalize user&apos;s experience and to allow us to deliver the type of content and product offerings in which you are most interested.</li>
+						<li>To allow us to better service you in responding to your customer service requests</li>
+						<li>To administer a contest, promotion, survey or other website feature</li>
+						<li>To send periodic emails regarding your interest for property listings and services</li>
+					</ul>
+					<p>
+						This website is the sole owner of the information collected. We will not sell, share, trade or rent this information to others in ways different from what is disclosed in this statement. This website collects information from
+						our users at several different points on our website. We ONLY collect personal information necessary to effectively market and to sell the property of sellers, to locate, assess and qualify properties for buyers and to
+						otherwise provide professional services to clients and customers. You may opt out of communications at any time. We do not sell, trade, transfer, rent or exchange your personal information with anyone. We do not disclose
+						information about your individual visits to this website, or personal information that you provide, such as your name, address, e-mail address, telephone number, etc., to any outside parties, except when we believe the law
+						requires it.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Home Worth / Dream Home / Neighbourhood Buzzer / Free Real Estate Reports</h2>
+					<p>
+						Since this website is a Real Estate website, we give you the OPTION of requesting FREE Real Estate Information about real estate properties. Your personal Information is stored on our secure database. We ONLY collect personal
+						information necessary to effectively market and to sell the property of sellers, to locate, assess and qualify properties for buyers and to otherwise provide professional services to clients and customers. We do not sell,
+						trade, transfer, rent or exchange your personal information with anyone.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Accessing YouTube API Services</h2>
+					<p>
+						This website uses YouTube API services to automatically generate YouTube videos of our listings on the YouTube channel. By using those API, we are agreeing to be bound by the YouTube Terms of Service and Google Privacy Policy.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Email links</h2>
+					<p>
+						This website provides an email address link located on the &apos;Contact Us&apos; page so that you may email us directly with any questions or comments you may have. This website reads all messages received and makes efforts
+						to respond promptly. In addition to replying to your comment or inquiry, we may also file your email for future reference regarding improvements to our website or discard the information. Your personal information is not
+						shared, traded, sold, or exchanged with any third parties without your express permission.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Do we use &apos;cookies&apos;?</h2>
+					<p>
+						Yes. Cookies are small files that a website or its service provider transfers to your computer&apos;s hard drive through your Web browser (if you allow) that enables the website&apos;s or service provider&apos;s systems to
+						recognize your browser and capture and remember certain information. They are used to help us understand your preferences based on previous or current website activity, which enables us to provide you with improved services.
+						We also use cookies to help us compile aggregate data about website traffic and website interaction so that we can offer better website experiences and tools in the future.
+					</p>
+					<p className="mt-4 font-semibold">This website uses the following cookies:</p>
+
+					<div className="mt-4">
+						<h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">1. Google Analytics</h3>
+						<p>
+							This cookie allows us to see information on user website activities including, but not limited to page views, source and time spent on websites. The information is depersonalised and is displayed as numbers, meaning it
+							cannot be tracked back to individuals. This will help to protect your privacy. Using Google Analytics we can see what content is popular on our website, and strive to give you more of the things you enjoy reading and
+							watching.
+						</p>
+					</div>
+
+					<div className="mt-4">
+						<h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">2. Google Ads</h3>
+						<p>Using Google AdWords code, we are able to see which pages helped lead to contact form submissions. This allows us to make better use of our paid search budget.</p>
+					</div>
+
+					<p className="mt-4">
+						You can choose to have your computer warn you each time a cookie is being sent, or you can choose to turn off all cookies. You do this through your browser (like Internet Explorer, Google Chrome, Safari, Firefox and other
+						browsers) settings. Each browser is a little different, so look at your browser&apos;s Help menu to learn the correct way to modify your cookies.
+					</p>
+					<p>
+						If you disable cookies, some features will be disabled, however, it won&apos;t affect the user experience that makes your website experience more efficient. Some of our services may or may not function properly as a result of
+						disabling cookies.
+					</p>
+					<p>
+						Google&apos;s advertising requirements can be summed up by Google&apos;s Advertising Principles. They are put in place to provide a positive experience for users. You can find more information here:{" "}
+						<a
+							href="https://support.google.com/adwordspolicy/answer/1316548?hl=en"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-blue-600 hover:underline"
+						>
+							https://support.google.com/adwordspolicy/answer/1316548?hl=en
+						</a>
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Third Party Disclosure</h2>
+					<p>
+						We do not sell, trade, or otherwise transfer to outside parties, your personally identifiable information unless we provide you with advance notice. This does not include website hosting partners and other parties who assist
+						us in operating our website, conducting our business, or servicing you, so long as those parties agree to keep this information confidential. We may also release your information when we believe release is appropriate to
+						comply with the law, enforce our website policies, or protect ours or others&apos; rights, property, or safety.
+					</p>
+					<p>However, non-personally identifiable visitor information may be provided to other parties for marketing, advertising, or other uses.</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Canada Anti-Spam Law (CASL)</h2>
+					<p>
+						CASL is a law that sets the rules for commercial email, establishes requirements for commercial messages, gives recipients the right to have emails stopped from being sent to them, and spells out tough penalties for
+						violations.
+					</p>
+					<p>We collect your email address in order to:</p>
+					<ul className="mb-4 ml-6 list-disc space-y-2">
+						<li>Send information, respond to inquiries, and/or other requests or questions.</li>
+						<li>Market to our mailing list or continue to send emails to our clients after the original transaction has occurred</li>
+					</ul>
+					<p>To be in accordance with CASL we agree to the following:</p>
+					<ul className="mb-4 ml-6 list-disc space-y-2">
+						<li>NOT use false, or misleading subjects or email addresses</li>
+						<li>Identify the message as an advertisement in some reasonable way</li>
+						<li>Include the physical address of our business or website headquarters</li>
+						<li>Monitor third party email marketing services for compliance, if one is used.</li>
+						<li>Honor opt-out/unsubscribe requests quickly</li>
+						<li>Allow users to unsubscribe by using the link at the bottom of each email</li>
+					</ul>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Opt-Out</h2>
+					<p>
+						This website provides users the opportunity to opt-out from our mailing list from their accounts. To do this, click on our &apos;Unsubscribe&apos; link found on the following pages: Neighborhood Buzzer/Home Worth/Dream
+						Home/FREE Real Estate Reports. You will be automatically removed from our subscription list upon unsubscribing.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Notification of Changes</h2>
+					<p>
+						This policy may be revised over time as new features are added to the website. We will post those changes so that you will always know what information we gather, how we might use that information, and whether we will disclose
+						it to anyone. Please check this website for information about revisions to our privacy policy. We will notify you directly if there is a material change in our privacy practices. We will take commercially reasonable measures
+						to obtain written or active e-mail consent from the user, if this website is going to be using the information collected from the user in a manner different from that stated at the time of collection. We will also post the
+						changes in our privacy statement 10 days prior to a change.
+					</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Legal Disclaimer</h2>
+					<p>We may disclose personal information when required by law or in the good-faith belief that such action is necessary in order to conform to the edicts of the law or comply with a legal process serviced on our website.</p>
+
+					<h2 className="mt-8 mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-50">Contacting Us</h2>
+					<p>
+						If you have any questions regarding our privacy policy please send us an{" "}
+						<a
+							href="/contact"
+							className="text-blue-600 hover:underline"
+						>
+							Email(Click Here)
+						</a>{" "}
+						and we will be pleased to assist.
+					</p>
+
+					<hr className="border-border my-16" />
+
+					<h1
+						id="disclaimer"
+						className="mb-8 text-3xl font-bold tracking-tighter text-zinc-900 sm:text-4xl md:text-5xl dark:text-zinc-50"
+					>
+						Disclaimer
+					</h1>
+					<p>
+						The information contained on this website is based in whole or in part on information that is provided by members of The Canadian Real Estate Association (CREA), who are responsible for its accuracy. CREA reproduces and
+						distributes this information as a service for its members and assumes no responsibility for its accuracy.
+					</p>
+					<p>This website is operated by Vince Villanueva, HomeLife Benchmark Titus Realty who is a member of The Canadian Real Estate Association.</p>
+					<p>
+						The listing content on this website is protected by copyright and other laws, and is intended solely for the private, non-commercial use by individuals. Any other reproduction, distribution or use of the content, in whole or
+						in part, is specifically forbidden. The prohibited uses include commercial use, &quot;screen scraping&quot;, &quot;database scraping&quot;, and any other activity intended to collect, store, reorganize or manipulate data on
+						the pages produced by or displayed on this website.
+					</p>
+					<p>
+						The information contained in this website is for general information purposes only. The information is provided by Vince Villanueva, HomeLife Benchmark Titus Realty and while we endeavor to keep the information up to date and
+						correct, we make no representations or warranties of any kind, express or implied, about the completeness, accuracy, reliability, suitability or availability with respect to the website or the information, products, services,
+						or related graphics contained on the website for any purpose. Any reliance you place on such information is therefore strictly at your own risk.
+					</p>
+					<p>
+						In no event will we be liable for any loss or damage including without limitation, indirect or consequential loss or damage, or any loss or damage whatsoever arising from loss of data or profit, arising out of, or in
+						connection with, the use of this website.
+					</p>
+					<p>
+						Through this website you are able to link to other websites which are not under the control of Vince Villanueva, HomeLife Benchmark Titus Realty. We have no control over the nature, content and availability of those sites. The
+						inclusion of any links does not necessarily imply a recommendation or endorse the views expressed within them.
+					</p>
+					<p>
+						Every effort is made to keep the website up and running smoothly. However, Vince Villanueva, HomeLife Benchmark Titus Realty takes no responsibility for, and will not be liable for, the website being temporarily unavailable
+						due to technical issues beyond our control.
+					</p>
+				</div>
+			</main>
+		</>
+	);
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,50 @@
+export default function TermsAndConditionsPage() {
+	return (
+		<>
+			<h1
+				id="terms"
+				className="mt-25 mb-8 text-3xl font-bold tracking-tighter text-zinc-900 sm:text-4xl md:text-5xl dark:text-zinc-50"
+			>
+				TERMS and CONDITIONS
+			</h1>
+			<p>
+				Welcome to our website. Please note that any access, use, or participation in this website constitutes an immediate acceptance and agreement to be bound by the terms and provision of this agreement. In addition, the use of particular
+				services provided by this website shall subject the user to any posted guidelines or rules applicable to such services, which may be posted and modified from time to time. All such guidelines or rules are hereby incorporated by
+				reference into the Terms of Service. The use of this website is not recommended and highly discouraged for those in disagreement with any part of the Terms of Service.
+			</p>
+			<p>From herein, the terms &apos;us&apos; or &apos;we&apos; or &apos;our&apos; will refer to the owner of the website. The terms &apos;you&apos; or &apos;your&apos; will refer to the user or viewer of this website.</p>
+			<p>The use of this website is subject to the following terms of use:</p>
+			<p>
+				This website and its components are offered for informational purposes only; neither we nor any third parties provide any warranty or guarantee as to the accuracy, timeliness, performance, completeness or suitability of the
+				information and materials found or offered on this website for any particular purpose. We shall not be held responsible or liable for the accuracy, usefulness or availability of any information transmitted or made available via the
+				website, and shall not be responsible or liable for any error or omissions in that information. The information in this website is subject to change without notice.
+			</p>
+			<p>
+				Your use of any information or materials in this website is entirely at your own risk, for which we shall not be held liable. It shall be your own responsibility to ensure that any products, services or information available through
+				this website meets your specific requirements.
+			</p>
+			<p>
+				This website uses &ldquo;cookies&rdquo; to monitor browsing preferences. Cookies are small pieces of information, including but not limited to, personal information stored by your browser on your computer&apos;s hard drive. Personal
+				information may be stored by us for use by third parties related to this website. Personal information includes but is not limited to, User Name, Password, and E-mail Address credentials used during registration for this website.
+			</p>
+			<p>
+				Our website contains registration forms which require users to provide contact information (first name, last name, phone number), unique identifiers (e-mail address), and demographic information (postal code, city, region). This
+				information will be stored, used, and shared within our brokerage and between members of our brokerage to serve your informational needs.
+			</p>
+			<p>
+				This website contains material which is owned by or licensed to us by InCom Web & e-Marketing Solutions. This material includes, but is not limited to, the design, layout, look, appearance, graphics, and content in this website.
+				Reproduction of said materials is prohibited other than in accordance with the copyright notice, which forms part of these terms and conditions.
+			</p>
+			<p>All trademarks reproduced in this website, which are not the property of, or licensed to the operator, are acknowledged in the website.</p>
+			<p>Unauthorized use of this website may give rise to a claim for damages and/or be a criminal offence.</p>
+			<p>
+				From time to time, this website may also include links to other website(s) or post(s). These links are provided for your convenience to provide further information. They do not signify that we endorse the website(s) or post(s). We
+				have no responsibility for the content of the linked website(s) or post(s). We the right to add, modify, remove all material of the website in its sole and absolute discretion including, without limitation, links and posts.
+			</p>
+			<p>This website uses YouTube API services to automatically generate YouTube videos of our listings on the YouTube channel. By using those API, we are agreeing to be bound by the YouTube Terms of Service and Google Privacy Policy.</p>
+			<p>Your use of this website and any dispute arising out of such use of the website is subject to the laws of Canada.</p>
+
+			<hr className="border-border my-16" />
+		</>
+	);
+}


### PR DESCRIPTION
This pull request introduces two new pages for privacy and terms, and makes minor adjustments to the not-found page. The most significant changes are the addition of comprehensive privacy policy, disclaimer, and terms and conditions content, as well as small tweaks to navigation and formatting.

**New legal and informational pages:**

* Added a detailed privacy policy and disclaimer page at `src/app/privacy/page.tsx`, including sections on personal information, cookies, third-party disclosure, Canadian Anti-Spam Law compliance, and legal disclaimers. The page also sets relevant metadata for SEO.
* Added a terms and conditions page at `src/app/terms/page.tsx`, outlining website usage terms, cookie policy, intellectual property, liability, and legal jurisdiction.

**Not-found page improvements:**

* Minor formatting adjustments to the `NotFound` component in `src/app/not-found.tsx` for cleaner markup.
* Fixed the "Listings" link in the not-found page to use a relative path, improving navigation reliability.