### PR TITLE
fix(lsp): missing type

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import HashReset from "@/utils/HashReset";
+import type {Metadata} from "next";
 
-export const metadata = {
+export const metadata: Metadata = {
 	title: "Privacy Policy & Disclaimer - Vince Villanueva Real Estate",
 	description: "Privacy Policy and Disclaimer for Vince Villanueva Real Estate.",
 };


### PR DESCRIPTION
This pull request makes a small update to the `metadata` export in the `src/app/privacy/page.tsx` file to explicitly type it as `Metadata` from Next.js. This improves type safety and clarity in the codebase.