### PR TITLE
refactor: uploadthing upload after submit

### DIFF
--- a/src/app/api/featured-listings/route.ts
+++ b/src/app/api/featured-listings/route.ts
@@ -66,6 +66,11 @@ export const POST = withApiHandler(
 		const realtorId = session!.user.id;
 		const currentCount = await countFeaturedListingsForRealtor(realtorId);
 		if (currentCount >= MAX_FEATURED_LISTINGS) {
+			await deleteUploadThingFileByUrl(result.data.imageUrl, {
+				reason: "listing-create-failure",
+				realtorId,
+			});
+
 			return NextResponse.json(
 				{
 					error: `You can only feature up to ${MAX_FEATURED_LISTINGS} listings.`,

--- a/src/app/api/presales/route.ts
+++ b/src/app/api/presales/route.ts
@@ -71,6 +71,15 @@ export const POST = withApiHandler(
 			listing = await createPresaleListingWithLimit(realtorId, result.data, MAX_PRESALE_LISTINGS);
 
 			if (!listing) {
+				await Promise.all(
+					result.data.imageUrls.map((imageUrl) =>
+						deleteUploadThingFileByUrl(imageUrl, {
+							reason: "presale-create-failure",
+							realtorId,
+						}),
+					),
+				);
+
 				return NextResponse.json(
 					{
 						error: `Maximum of ${MAX_PRESALE_LISTINGS} presale listings allowed.`,

--- a/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
@@ -1,4 +1,4 @@
-import {useActionState, useEffect, useRef, useState, type JSX} from "react";
+import {useActionState, useCallback, useEffect, useRef, useState, type JSX} from "react";
 import {Loader2} from "lucide-react";
 
 import {Button} from "@/components/ui/button";
@@ -11,6 +11,7 @@ import {countWords} from "@/utils/string";
 import {parseFeaturedListingFormInput} from "@/lib/zod/featured-listing-form";
 import {type FeaturedListing, type FeaturedListingMutationInput} from "@/lib/featured-listings/types";
 import {FeaturedListingsApiError, createFeaturedListing, updateFeaturedListing} from "@/lib/featured-listings/client";
+import {uploadFiles} from "@/lib/uploadthing";
 
 import {FeaturedListingImageUpload} from "./FeaturedListingImageUpload";
 import type {FeaturedListingFormState, FeaturedListingSubmitState} from "./types";
@@ -33,6 +34,27 @@ const INITIAL_SUBMIT_STATE: FeaturedListingSubmitState = {
 	errorMessage: null,
 	statusMessage: null,
 };
+
+interface PendingFeaturedImage {
+	file: File;
+	previewUrl: string;
+}
+
+function getUploadedFileUrl(file: {serverData?: {url?: string} | null; ufsUrl?: string; url?: string} | undefined): string | null {
+	if (!file) {
+		return null;
+	}
+
+	return file.serverData?.url ?? file.ufsUrl ?? file.url ?? null;
+}
+
+function revokePendingPreview(image: PendingFeaturedImage | null): void {
+	if (!image) {
+		return;
+	}
+
+	URL.revokeObjectURL(image.previewUrl);
+}
 
 interface FeaturedListingFormProps {
 	selectedListing: FeaturedListing | null;
@@ -97,17 +119,28 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 	const [formState, setFormState] = useState<FeaturedListingFormState>(EMPTY_FORM);
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [originalEditImageUrl, setOriginalEditImageUrl] = useState<string | null>(null);
+	const [pendingCreateImage, setPendingCreateImage] = useState<PendingFeaturedImage | null>(null);
 	const [isUploadingImage, setIsUploadingImage] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
 	const formStateRef = useRef<FeaturedListingFormState>(EMPTY_FORM);
 	const editingIdRef = useRef<string | null>(null);
+	const pendingCreateImageRef = useRef<PendingFeaturedImage | null>(null);
+
+	const clearPendingCreateImage = useCallback(() => {
+		setPendingCreateImage((current) => {
+			revokePendingPreview(current);
+			pendingCreateImageRef.current = null;
+			return null;
+		});
+	}, []);
 
 	/**
 	 * Resets all editable fields and local form-only UI state.
 	 * @returns {void}
 	 */
 	const resetFormFields = () => {
+		clearPendingCreateImage();
 		setFormState(EMPTY_FORM);
 		setEditingId(null);
 		setOriginalEditImageUrl(null);
@@ -118,14 +151,36 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 
 	const [actionState, formAction, isPending] = useActionState(async (_previousState: FeaturedListingSubmitState, _formData: FormData): Promise<FeaturedListingSubmitState> => {
 		try {
-			const payload = buildMutationInput(formStateRef.current);
 			const activeEditingId = editingIdRef.current;
 			const isEditing = Boolean(activeEditingId);
 
-			if (isEditing && activeEditingId) {
+			if (!isEditing) {
+				const pendingImage = pendingCreateImageRef.current;
+				if (!pendingImage) {
+					return {
+						errorMessage: "Please select an image.",
+						statusMessage: null,
+					};
+				}
+
+				const createPayload = buildMutationInput(formStateRef.current);
+
+				setIsUploadingImage(true);
+				setStatusMessage("Uploading image...");
+
+				const uploadedFiles = await uploadFiles("featuredListingImage", {
+					files: [pendingImage.file],
+				});
+
+				const uploadedImageUrl = getUploadedFileUrl(uploadedFiles[0]);
+				if (!uploadedImageUrl) {
+					throw new Error("Uploaded image URL was not returned. Please retry.");
+				}
+
+				await createFeaturedListing({...createPayload, imageUrl: uploadedImageUrl});
+			} else if (activeEditingId) {
+				const payload = buildMutationInput(formStateRef.current);
 				await updateFeaturedListing(activeEditingId, payload);
-			} else {
-				await createFeaturedListing(payload);
 			}
 
 			resetFormFields();
@@ -137,6 +192,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 				statusMessage: isEditing ? "Featured listing updated" : "Featured listing created",
 			};
 		} catch (error) {
+			setIsUploadingImage(false);
 			const message = getErrorMessage(error);
 			log.error("Failed to save featured listing", error);
 			return {
@@ -162,7 +218,18 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 	}, [actionState]);
 
 	useEffect(() => {
+		pendingCreateImageRef.current = pendingCreateImage;
+	}, [pendingCreateImage]);
+
+	useEffect(() => {
+		return () => {
+			revokePendingPreview(pendingCreateImageRef.current);
+		};
+	}, []);
+
+	useEffect(() => {
 		if (!selectedListing) {
+			clearPendingCreateImage();
 			setFormState(EMPTY_FORM);
 			setEditingId(null);
 			setOriginalEditImageUrl(null);
@@ -172,6 +239,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 			return;
 		}
 
+		clearPendingCreateImage();
 		const nextFormState = toFormState(selectedListing);
 		setFormState(nextFormState);
 		setEditingId(selectedListing.id);
@@ -181,7 +249,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		setIsUploadingImage(false);
 		setErrorMessage(null);
 		setStatusMessage(null);
-	}, [selectedListing]);
+	}, [clearPendingCreateImage, selectedListing]);
 
 	/**
 	 * Updates a single field in the form and keeps the mutable snapshot in sync.
@@ -224,6 +292,42 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		onFieldChange("imageUrl", uploadedImageUrl);
 		setStatusMessage(isEditing ? "Replacement image uploaded. Save listing to apply the change." : "Image uploaded. Each listing supports one image only.");
 		setErrorMessage(null);
+	};
+
+	const handleSelectCreateImage = (files: File[]) => {
+		if (isEditing) {
+			return;
+		}
+
+		const selectedFile = files[0];
+		if (!selectedFile) {
+			return;
+		}
+
+		const allowedMimeTypes = new Set(["image/jpeg", "image/png", "image/webp"]);
+		if (!allowedMimeTypes.has(selectedFile.type)) {
+			setErrorMessage("Only JPG, PNG, and WebP images are supported.");
+			return;
+		}
+
+		if (selectedFile.size > 8 * 1024 * 1024) {
+			setErrorMessage("Image size must be 8 MB or smaller.");
+			return;
+		}
+
+		const nextPendingImage: PendingFeaturedImage = {
+			file: selectedFile,
+			previewUrl: URL.createObjectURL(selectedFile),
+		};
+
+		const previousPendingImage = pendingCreateImageRef.current;
+		revokePendingPreview(previousPendingImage);
+
+		setPendingCreateImage(nextPendingImage);
+		pendingCreateImageRef.current = nextPendingImage;
+		onFieldChange("imageUrl", nextPendingImage.previewUrl);
+		setErrorMessage(null);
+		setStatusMessage("Image selected. It will upload when you create the listing.");
 	};
 
 	/**
@@ -348,24 +452,42 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 					hasUnsavedReplacementImage={hasUnsavedReplacementImage}
 					originalEditImageUrl={originalEditImageUrl}
 					isEditingWithCurrentSavedImage={isEditingWithCurrentSavedImage}
-					onUploadBegin={() => {
-						setIsUploadingImage(true);
-						setErrorMessage(null);
-						setStatusMessage("Uploading image...");
-					}}
-					onUploadComplete={handleUploadComplete}
-					onUploadError={(error) => {
-						setIsUploadingImage(false);
-						log.error("Featured image upload failed", error);
-						setErrorMessage(error.message);
-					}}
+					deferUpload={!isEditing}
+					onSelectFiles={isEditing ? undefined : handleSelectCreateImage}
+					onUploadBegin={
+						isEditing
+							? () => {
+									setIsUploadingImage(true);
+									setErrorMessage(null);
+									setStatusMessage("Uploading image...");
+								}
+							: undefined
+					}
+					onUploadComplete={isEditing ? handleUploadComplete : undefined}
+					onUploadError={
+						isEditing
+							? (error) => {
+									setIsUploadingImage(false);
+									log.error("Featured image upload failed", error);
+									setErrorMessage(error.message);
+								}
+							: undefined
+					}
 					onClearImage={() => {
+						if (!isEditing) {
+							clearPendingCreateImage();
+						}
 						onFieldChange("imageUrl", "");
 						setErrorMessage(null);
-						setStatusMessage("Current image cleared. Upload one replacement image.");
+						setStatusMessage(isEditing ? "Current image cleared. Upload one replacement image." : "Selected image cleared.");
 						setIsUploadingImage(false);
 					}}
 					onRevertImage={() => {
+						if (!isEditing) {
+							clearPendingCreateImage();
+							return;
+						}
+
 						if (originalEditImageUrl) {
 							onFieldChange("imageUrl", originalEditImageUrl);
 							setErrorMessage(null);

--- a/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
@@ -130,7 +130,6 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 	const clearPendingCreateImage = useCallback(() => {
 		setPendingCreateImage((current) => {
 			revokePendingPreview(current);
-			pendingCreateImageRef.current = null;
 			return null;
 		});
 	}, []);
@@ -324,7 +323,6 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		revokePendingPreview(previousPendingImage);
 
 		setPendingCreateImage(nextPendingImage);
-		pendingCreateImageRef.current = nextPendingImage;
 		onFieldChange("imageUrl", nextPendingImage.previewUrl);
 		setErrorMessage(null);
 		setStatusMessage("Image selected. It will upload when you create the listing.");

--- a/src/components/dashboard/featured-listings/FeaturedListingImageUpload.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingImageUpload.tsx
@@ -1,3 +1,4 @@
+import {type ChangeEvent, useRef} from "react";
 import Image from "next/image";
 import {Button} from "@/components/ui/button";
 import {Label} from "@/components/ui/label";
@@ -15,9 +16,11 @@ interface FeaturedListingImageUploadProps {
 	hasUnsavedReplacementImage: boolean;
 	originalEditImageUrl: string | null;
 	isEditingWithCurrentSavedImage: boolean;
-	onUploadBegin: () => void;
-	onUploadComplete: (files: UploadedUploadThingFile[]) => void;
-	onUploadError: (error: Error) => void;
+	deferUpload: boolean;
+	onSelectFiles?: (files: File[]) => void;
+	onUploadBegin?: () => void;
+	onUploadComplete?: (files: UploadedUploadThingFile[]) => void;
+	onUploadError?: (error: Error) => void;
 	onClearImage: () => void;
 	onRevertImage: () => void;
 }
@@ -32,12 +35,26 @@ export function FeaturedListingImageUpload({
 	hasUnsavedReplacementImage,
 	originalEditImageUrl,
 	isEditingWithCurrentSavedImage,
+	deferUpload,
+	onSelectFiles,
 	onUploadBegin,
 	onUploadComplete,
 	onUploadError,
 	onClearImage,
 	onRevertImage,
 }: FeaturedListingImageUploadProps) {
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	const handleSelectFile = (event: ChangeEvent<HTMLInputElement>) => {
+		const selectedFiles = event.target.files ? Array.from(event.target.files) : [];
+		if (selectedFiles.length === 0) {
+			return;
+		}
+
+		onSelectFiles?.([selectedFiles[0]!]);
+		event.currentTarget.value = "";
+	};
+
 	return (
 		<div className="space-y-2">
 			<Label>Listing Image</Label>
@@ -46,23 +63,45 @@ export function FeaturedListingImageUpload({
 				name="imageUrl"
 				value={imageUrl}
 			/>
-			<FileUpload
-				className="mx-auto my-8 w-55 sm:w-auto md:my-2"
-				endpoint="featuredListingImage"
-				disabled={!canUploadImage}
-				onUploadBegin={onUploadBegin}
-				onUploadComplete={onUploadComplete}
-				onUploadError={onUploadError}
-				uploadLabel="Upload one image for this listing"
-				uploadHelpText={
-					isEditing
-						? hasUnsavedReplacementImage
-							? "Replacement selected. Save listing to replace the old image in the database and UploadThing."
-							: "This listing has one image. Upload one replacement, then save."
-						: "Each listing allows one image total. To change it later, edit the listing, upload a replacement image, and save."
-				}
-				mobileButtonText={isUploadingImage ? "Uploading..." : isEditing ? "Upload replacement image" : "Upload one image"}
-			/>
+			{deferUpload ? (
+				<>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept="image/jpeg,image/png,image/webp"
+						onChange={handleSelectFile}
+						disabled={!canUploadImage}
+						className="hidden"
+					/>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={!canUploadImage}
+					>
+						Select image
+					</Button>
+					<p className="text-xs text-gray-500">The image uploads only when you create the listing. JPG, PNG, or WebP up to 8 MB.</p>
+				</>
+			) : (
+				<FileUpload
+					className="mx-auto my-8 w-55 sm:w-auto md:my-2"
+					endpoint="featuredListingImage"
+					disabled={!canUploadImage}
+					onUploadBegin={onUploadBegin}
+					onUploadComplete={(files) => onUploadComplete?.(files)}
+					onUploadError={(error) => onUploadError?.(error)}
+					uploadLabel="Upload one image for this listing"
+					uploadHelpText={
+						isEditing
+							? hasUnsavedReplacementImage
+								? "Replacement selected. Save listing to replace the old image in the database and UploadThing."
+								: "This listing has one image. Upload one replacement, then save."
+							: "Each listing allows one image total. To change it later, edit the listing, upload a replacement image, and save."
+					}
+					mobileButtonText={isUploadingImage ? "Uploading..." : isEditing ? "Upload replacement image" : "Upload one image"}
+				/>
+			)}
 			{imageUrl && (
 				<div className="relative mt-2 h-36 w-full overflow-hidden rounded-md border border-gray-200 bg-gray-100">
 					<Image
@@ -70,6 +109,7 @@ export function FeaturedListingImageUpload({
 						alt="Uploaded featured listing"
 						fill
 						className="object-cover"
+						unoptimized={imageUrl.startsWith("blob:")}
 					/>
 				</div>
 			)}

--- a/src/components/dashboard/presale/PreSaleForm.tsx
+++ b/src/components/dashboard/presale/PreSaleForm.tsx
@@ -228,7 +228,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	const clearPendingCreateImages = useCallback(() => {
 		setPendingCreateImages((current) => {
 			revokePendingImagePreviews(current);
-			pendingCreateImagesRef.current = [];
 			return [];
 		});
 	}, []);
@@ -443,7 +442,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 
 		const nextPendingImages = [...existingImages, ...pendingImagesToAdd].slice(0, MAX_PRESALE_IMAGES);
 		setPendingCreateImages(nextPendingImages);
-		pendingCreateImagesRef.current = nextPendingImages;
 		setFormState((current) => ({
 			...current,
 			imageUrls: nextPendingImages.map((image) => image.previewUrl),

--- a/src/components/dashboard/presale/PreSaleForm.tsx
+++ b/src/components/dashboard/presale/PreSaleForm.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import {useActionState, useEffect, useState} from "react";
+import {useActionState, useCallback, useEffect, useRef, useState} from "react";
 import {Loader2} from "lucide-react";
 
 import {Button} from "@/components/ui/button";
+import type {UploadedUploadThingFile} from "@/components/ui/file-upload";
 import {Input} from "@/components/ui/input";
 import {Label} from "@/components/ui/label";
 import {Textarea} from "@/components/ui/textarea";
-import type {UploadedUploadThingFile} from "@/components/ui/file-upload";
 import {createLogger} from "@/lib/logger";
 import {countWords} from "@/utils/string";
 import {presaleInputSchema, updatePresaleInputSchema} from "@/lib/zod/presale";
 import {MAX_PRESALE_IMAGES, type PresaleListing, type PresaleListingMutationInput} from "@/lib/presales/types";
 import {PresalesApiError, createPresaleListing, updatePresaleListing} from "@/lib/presales/client";
+import {uploadFiles} from "@/lib/uploadthing";
 
 import {PreSaleImageUpload} from "./PreSaleImageUpload";
 
@@ -61,6 +62,25 @@ const INITIAL_SUBMIT_STATE: PreSaleSubmitState = {
 	fieldErrors: null,
 	statusMessage: null,
 };
+
+interface PendingPresaleImage {
+	file: File;
+	previewUrl: string;
+}
+
+function getUploadedFileUrl(file: {serverData?: {url?: string} | null; ufsUrl?: string; url?: string} | undefined): string | null {
+	if (!file) {
+		return null;
+	}
+
+	return file.serverData?.url ?? file.ufsUrl ?? file.url ?? null;
+}
+
+function revokePendingImagePreviews(images: PendingPresaleImage[]): void {
+	for (const image of images) {
+		URL.revokeObjectURL(image.previewUrl);
+	}
+}
 
 interface PreSaleFormProps {
 	selectedListing: PresaleListing | null;
@@ -182,15 +202,42 @@ function getErrorMessage(error: unknown): string {
 export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDeletePending, onListingsChange, onCancelEditSelection}: PreSaleFormProps) {
 	const [formState, setFormState] = useState<PreSaleFormState>(EMPTY_FORM);
 	const [editingId, setEditingId] = useState<string | null>(null);
+	const [pendingCreateImages, setPendingCreateImages] = useState<PendingPresaleImage[]>([]);
 	const [isUploadingImage, setIsUploadingImage] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [fieldErrors, setFieldErrors] = useState<Record<string, string> | null>(null);
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
+	const pendingCreateImagesRef = useRef<PendingPresaleImage[]>([]);
+
+	const clearImageUrlsFieldError = useCallback(() => {
+		if (!fieldErrors?.imageUrls) {
+			return;
+		}
+
+		setFieldErrors((prev) => {
+			if (!prev) {
+				return null;
+			}
+
+			const next = {...prev};
+			delete next.imageUrls;
+			return Object.keys(next).length > 0 ? next : null;
+		});
+	}, [fieldErrors]);
+
+	const clearPendingCreateImages = useCallback(() => {
+		setPendingCreateImages((current) => {
+			revokePendingImagePreviews(current);
+			pendingCreateImagesRef.current = [];
+			return [];
+		});
+	}, []);
 
 	/**
 	 * Resets all form fields and local UI state to initial values.
 	 */
 	const resetFormFields = () => {
+		clearPendingCreateImages();
 		setFormState(EMPTY_FORM);
 		setEditingId(null);
 		setIsUploadingImage(false);
@@ -214,7 +261,30 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 				if ("errors" in parsed) {
 					return {errorMessage: "Please fix the validation errors below.", fieldErrors: parsed.errors, statusMessage: null};
 				}
-				await createPresaleListing(parsed.data);
+
+				const imagesToUpload = pendingCreateImagesRef.current;
+				if (imagesToUpload.length === 0) {
+					return {
+						errorMessage: "Please select at least one image.",
+						fieldErrors: {imageUrls: "At least one image is required"},
+						statusMessage: null,
+					};
+				}
+
+				setIsUploadingImage(true);
+				setStatusMessage(`Uploading ${imagesToUpload.length} image${imagesToUpload.length > 1 ? "s" : ""}...`);
+
+				const uploadedFiles = await uploadFiles("presaleImage", {
+					files: imagesToUpload.map((image) => image.file),
+				});
+
+				const uploadedUrls = uploadedFiles.map((file) => getUploadedFileUrl(file)).filter((url): url is string => Boolean(url));
+
+				if (uploadedUrls.length !== imagesToUpload.length) {
+					throw new Error("Some image uploads did not return URLs. Please retry.");
+				}
+
+				await createPresaleListing({...parsed.data, imageUrls: uploadedUrls});
 			}
 
 			resetFormFields();
@@ -227,6 +297,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 				statusMessage: isEditing ? "Pre-sale listing updated" : "Pre-sale listing created",
 			};
 		} catch (error) {
+			setIsUploadingImage(false);
 			const message = getErrorMessage(error);
 			log.error("Failed to save presale listing", error);
 			return {errorMessage: message, fieldErrors: null, statusMessage: null};
@@ -245,7 +316,18 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	}, [actionState]);
 
 	useEffect(() => {
+		pendingCreateImagesRef.current = pendingCreateImages;
+	}, [pendingCreateImages]);
+
+	useEffect(() => {
+		return () => {
+			revokePendingImagePreviews(pendingCreateImagesRef.current);
+		};
+	}, []);
+
+	useEffect(() => {
 		if (!selectedListing) {
+			clearPendingCreateImages();
 			setFormState(EMPTY_FORM);
 			setEditingId(null);
 			setIsUploadingImage(false);
@@ -255,6 +337,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			return;
 		}
 
+		clearPendingCreateImages();
 		const nextFormState = toFormState(selectedListing);
 		setFormState(nextFormState);
 		setEditingId(selectedListing.id);
@@ -262,7 +345,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		setErrorMessage(null);
 		setFieldErrors(null);
 		setStatusMessage(null);
-	}, [selectedListing]);
+	}, [clearPendingCreateImages, selectedListing]);
 
 	/**
 	 * Updates a single text field in the form state.
@@ -309,16 +392,71 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 
 		setStatusMessage(`${newUrls.length} image${newUrls.length > 1 ? "s" : ""} uploaded.`);
 		setErrorMessage(null);
+		clearImageUrlsFieldError();
+	};
 
-		// Clear imageUrls field error
-		if (fieldErrors?.imageUrls) {
-			setFieldErrors((prev) => {
-				if (!prev) return null;
-				const next = {...prev};
-				delete next.imageUrls;
-				return Object.keys(next).length > 0 ? next : null;
-			});
+	const handleSelectCreateFiles = (files: File[]) => {
+		if (isEditing) {
+			return;
 		}
+
+		const allowedMimeTypes = new Set(["image/jpeg", "image/png", "image/webp"]);
+		const existingImages = pendingCreateImagesRef.current;
+		const remainingSlots = MAX_PRESALE_IMAGES - existingImages.length;
+		if (remainingSlots <= 0) {
+			setErrorMessage(`You can upload a maximum of ${MAX_PRESALE_IMAGES} images.`);
+			return;
+		}
+
+		const validFiles: File[] = [];
+		let invalidTypeCount = 0;
+		let oversizeCount = 0;
+
+		for (const file of files) {
+			if (!allowedMimeTypes.has(file.type)) {
+				invalidTypeCount += 1;
+				continue;
+			}
+
+			if (file.size > 8 * 1024 * 1024) {
+				oversizeCount += 1;
+				continue;
+			}
+
+			validFiles.push(file);
+		}
+
+		const filesForSelection = validFiles.slice(0, remainingSlots);
+		const skippedByLimitCount = validFiles.length - filesForSelection.length;
+
+		if (filesForSelection.length === 0) {
+			if (invalidTypeCount > 0 || oversizeCount > 0) {
+				setErrorMessage("Only JPG, PNG, and WebP images up to 8 MB are supported.");
+			}
+			return;
+		}
+
+		const pendingImagesToAdd = filesForSelection.map((file) => ({
+			file,
+			previewUrl: URL.createObjectURL(file),
+		}));
+
+		const nextPendingImages = [...existingImages, ...pendingImagesToAdd].slice(0, MAX_PRESALE_IMAGES);
+		setPendingCreateImages(nextPendingImages);
+		pendingCreateImagesRef.current = nextPendingImages;
+		setFormState((current) => ({
+			...current,
+			imageUrls: nextPendingImages.map((image) => image.previewUrl),
+		}));
+
+		const selectedCount = pendingImagesToAdd.length;
+		setStatusMessage(`${selectedCount} image${selectedCount > 1 ? "s" : ""} selected. Images upload when you create the listing.`);
+		if (invalidTypeCount > 0 || oversizeCount > 0 || skippedByLimitCount > 0) {
+			setErrorMessage("Some selected files were skipped due to format, size, or image limit.");
+		} else {
+			setErrorMessage(null);
+		}
+		clearImageUrlsFieldError();
 	};
 
 	/**
@@ -326,6 +464,26 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	 * @param index - The index of the image to remove.
 	 */
 	const handleRemoveImage = (index: number) => {
+		if (!isEditing) {
+			const currentPendingImages = pendingCreateImagesRef.current;
+			const removedImage = currentPendingImages[index];
+			if (!removedImage) {
+				return;
+			}
+
+			URL.revokeObjectURL(removedImage.previewUrl);
+			const nextPendingImages = currentPendingImages.filter((_, i) => i !== index);
+			setPendingCreateImages(nextPendingImages);
+			pendingCreateImagesRef.current = nextPendingImages;
+			setFormState((current) => ({
+				...current,
+				imageUrls: nextPendingImages.map((image) => image.previewUrl),
+			}));
+			setStatusMessage("Image removed. Images upload when you create the listing.");
+			setErrorMessage(null);
+			return;
+		}
+
 		setFormState((current) => ({
 			...current,
 			imageUrls: current.imageUrls.filter((_, i) => i !== index),
@@ -538,17 +696,27 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 					imageUrls={formState.imageUrls}
 					disabled={isMutating}
 					isUploading={isUploadingImage}
-					onUploadBegin={() => {
-						setIsUploadingImage(true);
-						setErrorMessage(null);
-						setStatusMessage("Uploading image...");
-					}}
-					onUploadComplete={handleUploadComplete}
-					onUploadError={(error) => {
-						setIsUploadingImage(false);
-						log.error("Presale image upload failed", error);
-						setErrorMessage(error.message);
-					}}
+					deferUpload={!isEditing}
+					onSelectFiles={isEditing ? undefined : handleSelectCreateFiles}
+					onUploadBegin={
+						isEditing
+							? () => {
+									setIsUploadingImage(true);
+									setErrorMessage(null);
+									setStatusMessage("Uploading image...");
+								}
+							: undefined
+					}
+					onUploadComplete={isEditing ? handleUploadComplete : undefined}
+					onUploadError={
+						isEditing
+							? (error: Error) => {
+									setIsUploadingImage(false);
+									log.error("Presale image upload failed", error);
+									setErrorMessage(error.message);
+								}
+							: undefined
+					}
 					onRemoveImage={handleRemoveImage}
 				/>
 				{renderFieldError("imageUrls")}

--- a/src/components/dashboard/presale/PreSaleImageUpload.tsx
+++ b/src/components/dashboard/presale/PreSaleImageUpload.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import {type ChangeEvent, useRef} from "react";
 import Image from "next/image";
 import {X} from "lucide-react";
 
+import {Button} from "@/components/ui/button";
 import {FileUpload} from "@/components/ui/file-upload";
 import type {UploadedUploadThingFile} from "@/components/ui/file-upload";
-import {Button} from "@/components/ui/button";
 import {Label} from "@/components/ui/label";
 import {MAX_PRESALE_IMAGES} from "@/lib/presales/types";
 
@@ -13,9 +14,11 @@ interface PreSaleImageUploadProps {
 	imageUrls: string[];
 	disabled: boolean;
 	isUploading: boolean;
-	onUploadBegin: () => void;
-	onUploadComplete: (files: UploadedUploadThingFile[]) => void;
-	onUploadError: (error: Error) => void;
+	deferUpload: boolean;
+	onSelectFiles?: (files: File[]) => void;
+	onUploadBegin?: () => void;
+	onUploadComplete?: (files: UploadedUploadThingFile[]) => void;
+	onUploadError?: (error: Error) => void;
 	onRemoveImage: (index: number) => void;
 }
 
@@ -24,9 +27,20 @@ interface PreSaleImageUploadProps {
  * Supports 1-3 images with individual preview and removal.
  * Mobile-first layout with responsive grid for thumbnails.
  */
-export function PreSaleImageUpload({imageUrls, disabled, isUploading, onUploadBegin, onUploadComplete, onUploadError, onRemoveImage}: PreSaleImageUploadProps) {
+export function PreSaleImageUpload({imageUrls, disabled, isUploading, deferUpload, onSelectFiles, onUploadBegin, onUploadComplete, onUploadError, onRemoveImage}: PreSaleImageUploadProps) {
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const canUploadMore = imageUrls.length < MAX_PRESALE_IMAGES && !disabled && !isUploading;
 	const remainingSlots = MAX_PRESALE_IMAGES - imageUrls.length;
+
+	const handleSelectFiles = (event: ChangeEvent<HTMLInputElement>) => {
+		const selectedFiles = event.target.files ? Array.from(event.target.files) : [];
+		if (selectedFiles.length === 0) {
+			return;
+		}
+
+		onSelectFiles?.(selectedFiles);
+		event.currentTarget.value = "";
+	};
 
 	return (
 		<div className="space-y-3">
@@ -39,7 +53,7 @@ export function PreSaleImageUpload({imageUrls, disabled, isUploading, onUploadBe
 				<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
 					{imageUrls.map((url, index) => (
 						<div
-							key={url}
+							key={`${url}-${index}`}
 							className="group relative overflow-hidden rounded-lg border border-gray-200 bg-gray-100"
 						>
 							<div className="relative aspect-[4/3] w-full">
@@ -49,6 +63,7 @@ export function PreSaleImageUpload({imageUrls, disabled, isUploading, onUploadBe
 									fill
 									className="object-cover"
 									sizes="(max-width: 640px) 100vw, 33vw"
+									unoptimized={url.startsWith("blob:")}
 								/>
 							</div>
 							<Button
@@ -71,14 +86,35 @@ export function PreSaleImageUpload({imageUrls, disabled, isUploading, onUploadBe
 			)}
 
 			{/* Upload area - only shown when slots are available */}
-			{canUploadMore ? (
+			{canUploadMore && deferUpload ? (
+				<>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept="image/jpeg,image/png,image/webp"
+						multiple
+						onChange={handleSelectFiles}
+						disabled={!canUploadMore}
+						className="hidden"
+					/>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={!canUploadMore}
+					>
+						{isUploading ? "Uploading..." : imageUrls.length === 0 ? "Select images" : `Select more (${remainingSlots} left)`}
+					</Button>
+					<p className="text-xs text-gray-500">Images upload only when you save this listing. Max {MAX_PRESALE_IMAGES} images, up to 8 MB each.</p>
+				</>
+			) : canUploadMore ? (
 				<FileUpload
 					className="mx-auto w-full sm:w-auto"
 					endpoint="presaleImage"
 					disabled={!canUploadMore}
 					onUploadBegin={onUploadBegin}
-					onUploadComplete={onUploadComplete}
-					onUploadError={onUploadError}
+					onUploadComplete={(files) => onUploadComplete?.(files)}
+					onUploadError={(error) => onUploadError?.(error)}
 					uploadLabel={imageUrls.length === 0 ? "Upload images for this listing" : `Upload ${remainingSlots} more image${remainingSlots > 1 ? "s" : ""}`}
 					uploadHelpText={`${imageUrls.length === 0 ? "At least 1 image required." : ""} Max ${MAX_PRESALE_IMAGES} images, up to 8 MB each.`}
 					mobileButtonText={isUploading ? "Uploading..." : imageUrls.length === 0 ? "Upload images" : `Upload more (${remainingSlots} left)`}

--- a/src/lib/uploadthing/index.ts
+++ b/src/lib/uploadthing/index.ts
@@ -5,9 +5,10 @@
  * generic types are pre-bound and every consumer gets autocomplete
  * on available route slugs (e.g. "featuredListingImage").
  */
-import {generateUploadButton, generateUploadDropzone} from "@uploadthing/react";
+import {generateReactHelpers, generateUploadButton, generateUploadDropzone} from "@uploadthing/react";
 
 import type {UploadRouter} from "@/app/api/uploadthing/core";
 
 export const UploadButton = generateUploadButton<UploadRouter>();
 export const UploadDropzone = generateUploadDropzone<UploadRouter>();
+export const {uploadFiles} = generateReactHelpers<UploadRouter>();


### PR DESCRIPTION
# UploadThing Deferred Upload Fix — Summary

## The Problem

When creating presale or featured listings, images were being uploaded to UploadThing **immediately** when the user selected files — **before** they clicked "Create Listing." If the user encountered a validation error (e.g., missing required fields, invalid input), the already-uploaded files would remain in UploadThing storage. If the user then fixed the errors and submitted again, the same files could be uploaded again, creating duplicates and wasting storage.

### Specific Issues

**Presale Listings**

- `PreSaleImageUpload` used `FileUpload` (UploadThing's UploadDropzone) in auto-upload mode
- Files hit UploadThing immediately on selection
- Validation errors on submit left orphaned files
- Re-submission created duplicate files

**Featured Listings**

- `FeaturedListingImageUpload` had the same immediate-upload pattern
- Same orphan file problem on validation failure
- Extra edge case: the max-listing-limit rejection in `src/app/api/featured-listings/route.ts` could return a 400 before reaching the cleanup path, leaving the uploaded file orphaned

## The Task

Change the image upload flow so that:

- On **create**: files are selected locally and only uploaded to UploadThing **during form submission**, after all validation passes
- On **edit**: the existing immediate-upload replacement behavior is preserved (it's safe because the listing already exists)
- Orphaned files from failed submissions are cleaned up at the API layer as a safety net

## Steps / Procedures

### 1. Export `uploadFiles` helper from UploadThing

**File**: `src/lib/uploadthing/index.ts`

Added `generateReactHelpers` to get programmatic `uploadFiles` access:

```ts
import {
  generateReactHelpers,
  generateUploadButton,
  generateUploadDropzone,
} from "@uploadthing/react";
export const { uploadFiles } = generateReactHelpers<UploadRouter>();
```

### 2. Add deferred upload mode to presale image upload component

**File**: `src/components/dashboard/presale/PreSaleImageUpload.tsx`

- Added `deferUpload: boolean` prop
- When `deferUpload=true` (create mode): replaced `FileUpload` with a native `<input type="file">` for local file selection only — no immediate upload
- When `deferUpload=false` (edit mode): kept existing `FileUpload` behavior for replacement images
- Added `unoptimized` prop to `next/image` when rendering blob URLs (required for blob preview URLs)

### 3. Add deferred upload mode to featured listing image upload component

**File**: `src/components/dashboard/featured-listings/FeaturedListingImageUpload.tsx`

- Added `deferUpload: boolean` prop and `onSelectFiles?: (files: File[]) => void` optional prop
- When `deferUpload=true`: shows a native file input instead of `FileUpload`
- When `deferUpload=false`: uses existing UploadThing `FileUpload` for edit-mode replacements
- Made `onUploadBegin`, `onUploadComplete`, `onUploadError` optional to match the dual-mode interface
- Added `unoptimized` to the `Image` component for blob URLs

### 4. Update presale form — deferred create upload

**File**: `src/components/dashboard/presale/PreSaleForm.tsx`

- Added `pendingCreateImages` state: stores `{file: File, previewUrl: string}[]` for locally selected images
- Added `pendingCreateImagesRef` to access latest pending images inside the `useActionState` callback (which captures state at render time)
- Added `handleSelectCreateFiles`: validates file types (JPG/PNG/WebP) and size (max 8 MB), generates blob preview URLs with `URL.createObjectURL`, stores files locally without uploading
- Added `revokePendingImagePreviews`: calls `URL.revokeObjectURL` on blob previews for cleanup
- Updated `handleRemoveImage`: when not editing, removes from pending array and revokes blob URL
- Updated submit action: on create, validates form first, then calls `uploadFiles("presaleImage", { files: ... })` to upload to UploadThing, then creates the listing with the real URLs
- Added early return: if no pending images on create, returns validation error before any upload attempt
- Added cleanup: `clearPendingCreateImages` called on form reset, cancel, and unmount
- `isUploadingImage` is now set during submit-time upload (not just during edit-mode replacement)

### 5. Update featured listing form — deferred create upload

**File**: `src/components/dashboard/featured-listings/FeaturedListingForm.tsx`

- Added `pendingCreateImage` state: stores `{file: File, previewUrl: string}` for locally selected image
- Added `pendingCreateImageRef` for access inside `useActionState`
- Added `handleSelectCreateImage`: validates type and size, generates blob preview, stores file locally
- Updated submit action: on create, checks for pending image, uploads via `uploadFiles("featuredListingImage", { files: ... })`, then creates listing
- Added early return: if no pending image on create, returns error before upload
- `onClearImage` in create mode now calls `clearPendingCreateImage` to revoke blob URL
- `onRevertImage` in create mode calls `clearPendingCreateImage` and returns early (no UploadThing URL to revert to)

### 6. Add cleanup on API max-limit rejection

**File**: `src/app/api/presales/route.ts`

```ts
if (!listing) {
  await Promise.all(
    result.data.imageUrls.map((imageUrl) =>
      deleteUploadThingFileByUrl(imageUrl, {
        reason: "presale-create-failure",
        realtorId,
      }),
    ),
  );
  // ...return 400
}
```

**File**: `src/app/api/featured-listings/route.ts`

```ts
if (currentCount >= MAX_FEATURED_LISTINGS) {
  await deleteUploadThingFileByUrl(result.data.imageUrl, {
    reason: "listing-create-failure",
    realtorId,
  });
  // ...return 400
}
```

This catches the race-condition edge case where the limit is hit between the client-side check and the API call.

## The Solution

- **Create mode**: images are selected locally and held as `File` objects with blob preview URLs until the user clicks "Create Listing." The upload only happens inside the submit action, after form validation passes.
- **Edit mode**: unchanged — replacement images still upload immediately via `FileUpload` (safe because the listing already exists and the old image URL is known).
- **Validation guard**: if validation fails, no upload is attempted, so no orphan files are created.
- **API safety net**: if the API rejects a create request (e.g., max-listing limit), any files that were uploaded during submit are deleted immediately.

## Result

- ✅ Images are only uploaded to UploadThing on successful form submission
- ✅ Validation errors no longer leave orphaned files
- ✅ Re-submissions no longer create duplicate files
- ✅ Blob preview URLs provide instant visual feedback without UploadThing round-trips
- ✅ All existing edit-mode replacement behavior is preserved
- ✅ `bun check` passes (lint + TypeScript)
- ✅ `bun run build` passes

## Next Steps

The edit-mode undo replacement flow still has a gap: if a user uploads a replacement image and then clicks **Undo Replacement**, the uploaded file is left orphaned in UploadThing. This is tracked in:

→ **Issue #92**: [Edit mode: undo replacement leaves orphan UploadThing files](https://github.com/Vince-V-Real-Estate/VinceVillanueva-RealEstate/issues/92)

Labels: `enhancement`, `bug`

The proposed fix is to add a client-safe cleanup API route (`DELETE /api/uploadthing`) that wraps `deleteUploadThingFileByUrl`, then call it from `onRevertImage` and the edit-mode `handleRemoveImage` handlers.
