### PR TITLE
Dev

### DIFF
--- a/src/app/api/uploadthing-cleanup/route.ts
+++ b/src/app/api/uploadthing-cleanup/route.ts
@@ -1,0 +1,43 @@
+import {NextResponse} from "next/server";
+import {z} from "zod";
+
+import {createLogger} from "@/lib/logger";
+import {deleteUploadThingFileByUrl, extractUploadThingFileKey} from "@/server/uploadthing/cleanup";
+import {parseAndValidateBody, withApiHandler} from "@/utils/api/route-helpers";
+
+const log = createLogger("api-uploadthing-cleanup");
+
+const cleanupBodySchema = z.object({
+	url: z.string().url(),
+	reason: z.enum(["listing-image-replace", "presale-image-replace"]),
+});
+
+/**
+ * POST /api/uploadthing-cleanup
+ *
+ * Admin-only endpoint that deletes a single UploadThing file by its public URL.
+ * Used by the dashboard listing forms to clean up files that were uploaded but
+ * then immediately undone/removed by the user before the listing was saved
+ * (preventing orphan files in UploadThing storage).
+ *
+ * Server-side cleanup paths (PATCH/DELETE listing routes) handle
+ * already-saved file replacements; this endpoint covers the unsaved-undo gap.
+ */
+export const POST = withApiHandler({endpoint: "/api/uploadthing-cleanup", method: "POST", requireAuth: true, requireRole: "admin"}, async (request) => {
+	const result = await parseAndValidateBody(request, cleanupBodySchema);
+	if ("error" in result) {
+		return result.error;
+	}
+
+	const {url, reason} = result.data;
+
+	const fileKey = extractUploadThingFileKey(url);
+	if (!fileKey) {
+		log.warn("Rejected cleanup request for non-UploadThing URL", {url, reason});
+		return NextResponse.json({error: "Unsupported file URL"}, {status: 400});
+	}
+
+	await deleteUploadThingFileByUrl(url, {reason});
+
+	return {data: {deleted: true}};
+});

--- a/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
@@ -126,7 +126,27 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
 	const formStateRef = useRef<FeaturedListingFormState>(EMPTY_FORM);
 	const editingIdRef = useRef<string | null>(null);
+	const originalEditImageUrlRef = useRef<string | null>(null);
 	const pendingCreateImageRef = useRef<PendingFeaturedImage | null>(null);
+
+	const cleanupUnsavedReplacementImage = useCallback((imageUrl: string) => {
+		const normalizedImageUrl = imageUrl.trim();
+		const originalImageUrl = originalEditImageUrlRef.current?.trim() ?? "";
+
+		if (!editingIdRef.current || !normalizedImageUrl || !originalImageUrl) {
+			return;
+		}
+
+		if (normalizedImageUrl.startsWith("blob:") || normalizedImageUrl.startsWith("data:")) {
+			return;
+		}
+
+		if (normalizedImageUrl === originalImageUrl) {
+			return;
+		}
+
+		void requestUploadThingFileDeletion(normalizedImageUrl, "listing-image-replace");
+	}, []);
 
 	const clearPendingCreateImage = useCallback(() => {
 		setPendingCreateImage((current) => {
@@ -146,6 +166,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		setOriginalEditImageUrl(null);
 		formStateRef.current = EMPTY_FORM;
 		editingIdRef.current = null;
+		originalEditImageUrlRef.current = null;
 		setIsUploadingImage(false);
 	};
 
@@ -223,11 +244,14 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 
 	useEffect(() => {
 		return () => {
+			cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
 			revokePendingPreview(pendingCreateImageRef.current);
 		};
-	}, []);
+	}, [cleanupUnsavedReplacementImage]);
 
 	useEffect(() => {
+		cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
+
 		if (!selectedListing) {
 			clearPendingCreateImage();
 			setFormState(EMPTY_FORM);
@@ -235,6 +259,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 			setOriginalEditImageUrl(null);
 			formStateRef.current = EMPTY_FORM;
 			editingIdRef.current = null;
+			originalEditImageUrlRef.current = null;
 			setIsUploadingImage(false);
 			return;
 		}
@@ -246,10 +271,11 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		setOriginalEditImageUrl(selectedListing.imageUrl);
 		formStateRef.current = nextFormState;
 		editingIdRef.current = selectedListing.id;
+		originalEditImageUrlRef.current = selectedListing.imageUrl;
 		setIsUploadingImage(false);
 		setErrorMessage(null);
 		setStatusMessage(null);
-	}, [clearPendingCreateImage, selectedListing]);
+	}, [cleanupUnsavedReplacementImage, clearPendingCreateImage, selectedListing]);
 
 	/**
 	 * Updates a single field in the form and keeps the mutable snapshot in sync.
@@ -288,6 +314,8 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 			setErrorMessage("Uploaded image URL was not returned. Please retry.");
 			return;
 		}
+
+		cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
 
 		onFieldChange("imageUrl", uploadedImageUrl);
 		setStatusMessage(isEditing ? "Replacement image uploaded. Save listing to apply the change." : "Image uploaded. Each listing supports one image only.");
@@ -334,6 +362,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 	 * @returns {void}
 	 */
 	const handleCancelEdit = () => {
+		cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
 		resetFormFields();
 		onCancelEditSelection();
 	};
@@ -475,6 +504,8 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 					onClearImage={() => {
 						if (!isEditing) {
 							clearPendingCreateImage();
+						} else {
+							cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
 						}
 						onFieldChange("imageUrl", "");
 						setErrorMessage(null);
@@ -488,10 +519,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 						}
 
 						if (originalEditImageUrl) {
-							const replacementUrl = formState.imageUrl.trim();
-							if (replacementUrl && replacementUrl !== originalEditImageUrl) {
-								void requestUploadThingFileDeletion(replacementUrl, "listing-image-replace");
-							}
+							cleanupUnsavedReplacementImage(formStateRef.current.imageUrl);
 
 							onFieldChange("imageUrl", originalEditImageUrl);
 							setErrorMessage(null);

--- a/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
@@ -133,7 +133,7 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 		const normalizedImageUrl = imageUrl.trim();
 		const originalImageUrl = originalEditImageUrlRef.current?.trim() ?? "";
 
-		if (!editingIdRef.current || !normalizedImageUrl || !originalImageUrl) {
+		if (!editingIdRef.current || !normalizedImageUrl) {
 			return;
 		}
 

--- a/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
+++ b/src/components/dashboard/featured-listings/FeaturedListingForm.tsx
@@ -12,6 +12,7 @@ import {parseFeaturedListingFormInput} from "@/lib/zod/featured-listing-form";
 import {type FeaturedListing, type FeaturedListingMutationInput} from "@/lib/featured-listings/types";
 import {FeaturedListingsApiError, createFeaturedListing, updateFeaturedListing} from "@/lib/featured-listings/client";
 import {uploadFiles} from "@/lib/uploadthing";
+import {requestUploadThingFileDeletion} from "@/lib/uploadthing/cleanup";
 
 import {FeaturedListingImageUpload} from "./FeaturedListingImageUpload";
 import type {FeaturedListingFormState, FeaturedListingSubmitState} from "./types";
@@ -487,6 +488,11 @@ export function FeaturedListingForm({selectedListing, listingsCount, canCreateMo
 						}
 
 						if (originalEditImageUrl) {
+							const replacementUrl = formState.imageUrl.trim();
+							if (replacementUrl && replacementUrl !== originalEditImageUrl) {
+								void requestUploadThingFileDeletion(replacementUrl, "listing-image-replace");
+							}
+
 							onFieldChange("imageUrl", originalEditImageUrl);
 							setErrorMessage(null);
 							setStatusMessage("Reverted to the current saved image.");

--- a/src/components/dashboard/presale/PreSaleForm.tsx
+++ b/src/components/dashboard/presale/PreSaleForm.tsx
@@ -14,6 +14,7 @@ import {presaleInputSchema, updatePresaleInputSchema} from "@/lib/zod/presale";
 import {MAX_PRESALE_IMAGES, type PresaleListing, type PresaleListingMutationInput} from "@/lib/presales/types";
 import {PresalesApiError, createPresaleListing, updatePresaleListing} from "@/lib/presales/client";
 import {uploadFiles} from "@/lib/uploadthing";
+import {requestUploadThingFileDeletion} from "@/lib/uploadthing/cleanup";
 
 import {PreSaleImageUpload} from "./PreSaleImageUpload";
 
@@ -202,6 +203,7 @@ function getErrorMessage(error: unknown): string {
 export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDeletePending, onListingsChange, onCancelEditSelection}: PreSaleFormProps) {
 	const [formState, setFormState] = useState<PreSaleFormState>(EMPTY_FORM);
 	const [editingId, setEditingId] = useState<string | null>(null);
+	const [originalEditImageUrls, setOriginalEditImageUrls] = useState<string[]>([]);
 	const [pendingCreateImages, setPendingCreateImages] = useState<PendingPresaleImage[]>([]);
 	const [isUploadingImage, setIsUploadingImage] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -239,6 +241,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		clearPendingCreateImages();
 		setFormState(EMPTY_FORM);
 		setEditingId(null);
+		setOriginalEditImageUrls([]);
 		setIsUploadingImage(false);
 		setFieldErrors(null);
 	};
@@ -329,6 +332,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			clearPendingCreateImages();
 			setFormState(EMPTY_FORM);
 			setEditingId(null);
+			setOriginalEditImageUrls([]);
 			setIsUploadingImage(false);
 			setErrorMessage(null);
 			setFieldErrors(null);
@@ -340,6 +344,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		const nextFormState = toFormState(selectedListing);
 		setFormState(nextFormState);
 		setEditingId(selectedListing.id);
+		setOriginalEditImageUrls([...selectedListing.imageUrls]);
 		setIsUploadingImage(false);
 		setErrorMessage(null);
 		setFieldErrors(null);
@@ -480,6 +485,11 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			setStatusMessage("Image removed. Images upload when you create the listing.");
 			setErrorMessage(null);
 			return;
+		}
+
+		const removedUrl = formState.imageUrls[index];
+		if (removedUrl && !removedUrl.startsWith("blob:") && !removedUrl.startsWith("data:") && !originalEditImageUrls.includes(removedUrl)) {
+			void requestUploadThingFileDeletion(removedUrl, "presale-image-replace");
 		}
 
 		setFormState((current) => ({

--- a/src/components/dashboard/presale/PreSaleForm.tsx
+++ b/src/components/dashboard/presale/PreSaleForm.tsx
@@ -83,6 +83,32 @@ function revokePendingImagePreviews(images: PendingPresaleImage[]): void {
 	}
 }
 
+function normalizePersistedImageUrl(imageUrl: string): string | null {
+	const normalizedUrl = imageUrl.trim();
+	if (!normalizedUrl || normalizedUrl.startsWith("blob:") || normalizedUrl.startsWith("data:")) {
+		return null;
+	}
+
+	return normalizedUrl;
+}
+
+function getUnsavedUploadedImageUrls(imageUrls: string[], originalImageUrls: string[]): string[] {
+	const originalImageUrlSet = new Set(originalImageUrls.map((imageUrl) => normalizePersistedImageUrl(imageUrl)).filter((imageUrl): imageUrl is string => Boolean(imageUrl)));
+
+	const unsavedImageUrls: string[] = [];
+
+	for (const imageUrl of imageUrls) {
+		const normalizedImageUrl = normalizePersistedImageUrl(imageUrl);
+		if (!normalizedImageUrl || originalImageUrlSet.has(normalizedImageUrl)) {
+			continue;
+		}
+
+		unsavedImageUrls.push(normalizedImageUrl);
+	}
+
+	return unsavedImageUrls;
+}
+
 interface PreSaleFormProps {
 	selectedListing: PresaleListing | null;
 	listingsCount: number;
@@ -209,7 +235,21 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [fieldErrors, setFieldErrors] = useState<Record<string, string> | null>(null);
 	const [statusMessage, setStatusMessage] = useState<string | null>(null);
+	const formStateRef = useRef<PreSaleFormState>(EMPTY_FORM);
+	const editingIdRef = useRef<string | null>(null);
+	const originalEditImageUrlsRef = useRef<string[]>([]);
 	const pendingCreateImagesRef = useRef<PendingPresaleImage[]>([]);
+
+	const cleanupUnsavedEditImages = useCallback((imageUrls: string[]) => {
+		if (!editingIdRef.current || imageUrls.length === 0) {
+			return;
+		}
+
+		const unsavedImageUrls = getUnsavedUploadedImageUrls(imageUrls, originalEditImageUrlsRef.current);
+		for (const unsavedImageUrl of unsavedImageUrls) {
+			void requestUploadThingFileDeletion(unsavedImageUrl, "presale-image-replace");
+		}
+	}, []);
 
 	const clearImageUrlsFieldError = useCallback(() => {
 		if (!fieldErrors?.imageUrls) {
@@ -242,6 +282,9 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		setFormState(EMPTY_FORM);
 		setEditingId(null);
 		setOriginalEditImageUrls([]);
+		formStateRef.current = EMPTY_FORM;
+		editingIdRef.current = null;
+		originalEditImageUrlsRef.current = [];
 		setIsUploadingImage(false);
 		setFieldErrors(null);
 	};
@@ -318,21 +361,33 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	}, [actionState]);
 
 	useEffect(() => {
+		formStateRef.current = formState;
+		editingIdRef.current = editingId;
+		originalEditImageUrlsRef.current = originalEditImageUrls;
+	}, [editingId, formState, originalEditImageUrls]);
+
+	useEffect(() => {
 		pendingCreateImagesRef.current = pendingCreateImages;
 	}, [pendingCreateImages]);
 
 	useEffect(() => {
 		return () => {
+			cleanupUnsavedEditImages(formStateRef.current.imageUrls);
 			revokePendingImagePreviews(pendingCreateImagesRef.current);
 		};
-	}, []);
+	}, [cleanupUnsavedEditImages]);
 
 	useEffect(() => {
+		cleanupUnsavedEditImages(formStateRef.current.imageUrls);
+
 		if (!selectedListing) {
 			clearPendingCreateImages();
 			setFormState(EMPTY_FORM);
 			setEditingId(null);
 			setOriginalEditImageUrls([]);
+			formStateRef.current = EMPTY_FORM;
+			editingIdRef.current = null;
+			originalEditImageUrlsRef.current = [];
 			setIsUploadingImage(false);
 			setErrorMessage(null);
 			setFieldErrors(null);
@@ -345,11 +400,14 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		setFormState(nextFormState);
 		setEditingId(selectedListing.id);
 		setOriginalEditImageUrls([...selectedListing.imageUrls]);
+		formStateRef.current = nextFormState;
+		editingIdRef.current = selectedListing.id;
+		originalEditImageUrlsRef.current = [...selectedListing.imageUrls];
 		setIsUploadingImage(false);
 		setErrorMessage(null);
 		setFieldErrors(null);
 		setStatusMessage(null);
-	}, [clearPendingCreateImages, selectedListing]);
+	}, [cleanupUnsavedEditImages, clearPendingCreateImages, selectedListing]);
 
 	/**
 	 * Updates a single text field in the form state.
@@ -389,10 +447,20 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			return;
 		}
 
+		const currentImageUrls = formStateRef.current.imageUrls;
+		const combinedImageUrls = [...currentImageUrls, ...newUrls];
+		const nextImageUrls = combinedImageUrls.slice(0, MAX_PRESALE_IMAGES);
+		const droppedImageUrls = combinedImageUrls.slice(MAX_PRESALE_IMAGES);
+		cleanupUnsavedEditImages(droppedImageUrls);
+
 		setFormState((current) => ({
 			...current,
-			imageUrls: [...current.imageUrls, ...newUrls].slice(0, MAX_PRESALE_IMAGES),
+			imageUrls: nextImageUrls,
 		}));
+		formStateRef.current = {
+			...formStateRef.current,
+			imageUrls: nextImageUrls,
+		};
 
 		setStatusMessage(`${newUrls.length} image${newUrls.length > 1 ? "s" : ""} uploaded.`);
 		setErrorMessage(null);
@@ -488,8 +556,8 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		}
 
 		const removedUrl = formState.imageUrls[index];
-		if (removedUrl && !removedUrl.startsWith("blob:") && !removedUrl.startsWith("data:") && !originalEditImageUrls.includes(removedUrl)) {
-			void requestUploadThingFileDeletion(removedUrl, "presale-image-replace");
+		if (removedUrl) {
+			cleanupUnsavedEditImages([removedUrl]);
 		}
 
 		setFormState((current) => ({
@@ -503,6 +571,7 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	 * Cancels edit mode, clears form state, and resets manager selection.
 	 */
 	const handleCancelEdit = () => {
+		cleanupUnsavedEditImages(formStateRef.current.imageUrls);
 		resetFormFields();
 		onCancelEditSelection();
 	};

--- a/src/components/dashboard/presale/PreSaleForm.tsx
+++ b/src/components/dashboard/presale/PreSaleForm.tsx
@@ -229,7 +229,6 @@ function getErrorMessage(error: unknown): string {
 export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDeletePending, onListingsChange, onCancelEditSelection}: PreSaleFormProps) {
 	const [formState, setFormState] = useState<PreSaleFormState>(EMPTY_FORM);
 	const [editingId, setEditingId] = useState<string | null>(null);
-	const [originalEditImageUrls, setOriginalEditImageUrls] = useState<string[]>([]);
 	const [pendingCreateImages, setPendingCreateImages] = useState<PendingPresaleImage[]>([]);
 	const [isUploadingImage, setIsUploadingImage] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -281,7 +280,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		clearPendingCreateImages();
 		setFormState(EMPTY_FORM);
 		setEditingId(null);
-		setOriginalEditImageUrls([]);
 		formStateRef.current = EMPTY_FORM;
 		editingIdRef.current = null;
 		originalEditImageUrlsRef.current = [];
@@ -361,12 +359,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	}, [actionState]);
 
 	useEffect(() => {
-		formStateRef.current = formState;
-		editingIdRef.current = editingId;
-		originalEditImageUrlsRef.current = originalEditImageUrls;
-	}, [editingId, formState, originalEditImageUrls]);
-
-	useEffect(() => {
 		pendingCreateImagesRef.current = pendingCreateImages;
 	}, [pendingCreateImages]);
 
@@ -384,7 +376,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			clearPendingCreateImages();
 			setFormState(EMPTY_FORM);
 			setEditingId(null);
-			setOriginalEditImageUrls([]);
 			formStateRef.current = EMPTY_FORM;
 			editingIdRef.current = null;
 			originalEditImageUrlsRef.current = [];
@@ -399,7 +390,6 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		const nextFormState = toFormState(selectedListing);
 		setFormState(nextFormState);
 		setEditingId(selectedListing.id);
-		setOriginalEditImageUrls([...selectedListing.imageUrls]);
 		formStateRef.current = nextFormState;
 		editingIdRef.current = selectedListing.id;
 		originalEditImageUrlsRef.current = [...selectedListing.imageUrls];
@@ -415,7 +405,11 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 	 * @param value - The new field value.
 	 */
 	const onFieldChange = (field: keyof Omit<PreSaleFormState, "imageUrls">, value: string) => {
-		setFormState((current) => ({...current, [field]: value}));
+		setFormState((current) => {
+			const nextState = {...current, [field]: value};
+			formStateRef.current = nextState;
+			return nextState;
+		});
 		// Clear field-specific error on change
 		if (fieldErrors?.[field]) {
 			setFieldErrors((prev) => {
@@ -453,14 +447,14 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 		const droppedImageUrls = combinedImageUrls.slice(MAX_PRESALE_IMAGES);
 		cleanupUnsavedEditImages(droppedImageUrls);
 
-		setFormState((current) => ({
-			...current,
-			imageUrls: nextImageUrls,
-		}));
-		formStateRef.current = {
-			...formStateRef.current,
-			imageUrls: nextImageUrls,
-		};
+		setFormState((current) => {
+			const nextState = {
+				...current,
+				imageUrls: nextImageUrls,
+			};
+			formStateRef.current = nextState;
+			return nextState;
+		});
 
 		setStatusMessage(`${newUrls.length} image${newUrls.length > 1 ? "s" : ""} uploaded.`);
 		setErrorMessage(null);
@@ -515,10 +509,15 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 
 		const nextPendingImages = [...existingImages, ...pendingImagesToAdd].slice(0, MAX_PRESALE_IMAGES);
 		setPendingCreateImages(nextPendingImages);
-		setFormState((current) => ({
-			...current,
-			imageUrls: nextPendingImages.map((image) => image.previewUrl),
-		}));
+		const nextImageUrls = nextPendingImages.map((image) => image.previewUrl);
+		setFormState((current) => {
+			const nextState = {
+				...current,
+				imageUrls: nextImageUrls,
+			};
+			formStateRef.current = nextState;
+			return nextState;
+		});
 
 		const selectedCount = pendingImagesToAdd.length;
 		setStatusMessage(`${selectedCount} image${selectedCount > 1 ? "s" : ""} selected. Images upload when you create the listing.`);
@@ -546,24 +545,33 @@ export function PreSaleForm({selectedListing, listingsCount, canCreateMore, isDe
 			const nextPendingImages = currentPendingImages.filter((_, i) => i !== index);
 			setPendingCreateImages(nextPendingImages);
 			pendingCreateImagesRef.current = nextPendingImages;
-			setFormState((current) => ({
-				...current,
-				imageUrls: nextPendingImages.map((image) => image.previewUrl),
-			}));
+			const nextImageUrls = nextPendingImages.map((image) => image.previewUrl);
+			setFormState((current) => {
+				const nextState = {
+					...current,
+					imageUrls: nextImageUrls,
+				};
+				formStateRef.current = nextState;
+				return nextState;
+			});
 			setStatusMessage("Image removed. Images upload when you create the listing.");
 			setErrorMessage(null);
 			return;
 		}
 
-		const removedUrl = formState.imageUrls[index];
+		const removedUrl = formStateRef.current.imageUrls[index];
 		if (removedUrl) {
 			cleanupUnsavedEditImages([removedUrl]);
 		}
 
-		setFormState((current) => ({
-			...current,
-			imageUrls: current.imageUrls.filter((_, i) => i !== index),
-		}));
+		setFormState((current) => {
+			const nextState = {
+				...current,
+				imageUrls: current.imageUrls.filter((_, i) => i !== index),
+			};
+			formStateRef.current = nextState;
+			return nextState;
+		});
 		setStatusMessage("Image removed. Save listing to persist the change.");
 	};
 

--- a/src/lib/uploadthing/cleanup.ts
+++ b/src/lib/uploadthing/cleanup.ts
@@ -1,0 +1,50 @@
+import {createLogger} from "@/lib/logger";
+
+const log = createLogger("uploadthing-client-cleanup");
+
+/** Reason codes accepted by the `/api/uploadthing-cleanup` endpoint. */
+export type UploadThingClientCleanupReason = "listing-image-replace" | "presale-image-replace";
+
+/**
+ * Requests deletion of a single UploadThing file from a client component.
+ *
+ * Used by listing edit forms to clean up replacement files that the user
+ * uploaded and then undid/removed before saving, preventing orphan files
+ * from accumulating in UploadThing storage.
+ *
+ * This call is fire-and-forget by design: it never throws and never blocks
+ * the UI. Network or server failures are logged at warn level so that an
+ * orphan file (recoverable manually) is preferred over a UI that locks up
+ * during an undo interaction.
+ *
+ * Local-only URLs (empty, `blob:`, or `data:`) are skipped because they
+ * represent unsubmitted previews that have not been uploaded yet.
+ *
+ * @param url - The public URL of the file to delete.
+ * @param reason - Context tag forwarded to the server for logging.
+ * @returns A promise that always resolves; failures are logged, not thrown.
+ */
+export async function requestUploadThingFileDeletion(url: string, reason: UploadThingClientCleanupReason): Promise<void> {
+	const trimmedUrl = url.trim();
+	if (!trimmedUrl || trimmedUrl.startsWith("blob:") || trimmedUrl.startsWith("data:")) {
+		return;
+	}
+
+	try {
+		const response = await fetch("/api/uploadthing-cleanup", {
+			method: "POST",
+			headers: {"Content-Type": "application/json"},
+			body: JSON.stringify({url: trimmedUrl, reason}),
+		});
+
+		if (!response.ok) {
+			log.warn("UploadThing cleanup endpoint returned non-OK", {
+				status: response.status,
+				url: trimmedUrl,
+				reason,
+			});
+		}
+	} catch (error) {
+		log.warn("UploadThing cleanup request failed", {url: trimmedUrl, reason, error});
+	}
+}


### PR DESCRIPTION
---
Goal
Fix GitHub issue #92 in the Vince-V-Real-Estate/VinceVillanueva-RealEstate repo: orphan UploadThing files left behind when admins upload replacement images in listing edit forms but then undo, clear, overwrite, or cancel before saving. Both the featured listing form (single image) and presale form (multiple images, max MAX_PRESALE_IMAGES) are affected.
Instructions
- The user prefers we stay in plan mode for proposals and only build when explicitly told to.
- Cleanup helper must be fire-and-forget: never throws, never blocks UI; orphan file is preferable to a frozen undo button.
- Auth on the new endpoint uses requireRole: "admin" (confirmed by user via "go ahead" after the recommendation).
- Follow AGENTS.md: use withApiHandler, parseAndValidateBody, createLogger, request-scoped auth, Tailwind only, no client imports of server-only modules (@/server/uploadthing/cleanup is server-only).
- Quality gates to run: bun check, bun format:check, bun run build.
- The user accepted Gemini Code Assist review feedback to expand cleanup beyond just undo to also cover: overwrite, clear, cancel-edit, listing-switch, unmount, and (presale) overflow-on-upload.
Discoveries
- Existing server-side cleanup runs only on save (PATCH /api/featured-listings/[id], PATCH /api/presales/[id]), comparing DB state to incoming payload. Files uploaded but never saved are invisible to that diff.
- src/server/uploadthing/cleanup.ts exports deleteUploadThingFileByUrl(url, { reason }) and extractUploadThingFileKey(url) — server-only.
- src/utils/api/route-helpers.ts provides withApiHandler with requireAuth / requireRole: "client" | "admin" and parseAndValidateBody.
- The existing /api/uploadthing route uses createRouteHandler from UploadThing's package, so a separate path (/api/uploadthing-cleanup) avoids conflict.
- The DeleteUploadThingFileByUrlOptions.reason enum already includes "listing-image-replace" and "presale-image-replace".
- Pre-existing unrelated lint warning in src/components/sections/Contact.tsx (officeHours unused) — leave untouched.
Accomplished
Completed (committed to working tree, all gates passing):
1. Created src/app/api/uploadthing-cleanup/route.ts — admin-only POST endpoint, validates URL is UploadThing host, calls deleteUploadThingFileByUrl.
2. Created src/lib/uploadthing/cleanup.ts — requestUploadThingFileDeletion(url, reason) client helper; skips blob:/data:/empty; never throws.
3. Modified FeaturedListingForm.tsx:
   - Added originalEditImageUrlRef and centralized cleanupUnsavedReplacementImage(imageUrl) callback.
   - Wired into: onRevertImage, onClearImage (edit branch), handleUploadComplete (overwrite), handleCancelEdit, selectedListing change effect, unmount effect.
4. Modified PreSaleForm.tsx:
   - Added module helpers normalizePersistedImageUrl and getUnsavedUploadedImageUrls.
   - Added refs formStateRef, editingIdRef, originalEditImageUrlsRef (synced via dedicated effect + inline writes).
   - Added centralized cleanupUnsavedEditImages(urls) callback.
   - Wired into: handleRemoveImage (edit branch), handleUploadComplete (overflow drop when exceeding MAX_PRESALE_IMAGES), handleCancelEdit, selectedListing change effect, unmount effect.
5. Verified: bun check ✅, bun format:check ✅, bun run build ✅ (new route registered).
6. Created ~/Desktop/issue-92-fix-summary.md (initial summary — does NOT yet reflect the expanded Gemini-feedback cleanup paths; user may want it updated).
7. Provided two PR description drafts in the conversation (last one is the comprehensive copy-paste-ready markdown including full implementation breakdown, file table, and manual smoke test checklist).
Not done / potential follow-ups:
- The ~/Desktop/issue-92-fix-summary.md was written before the expanded cleanup work; it currently only mentions undo (featured) and remove (presale). Offered to update it but user did not confirm — they instead asked for the PR description markdown.
- No commit has been made — all changes are unstaged in the working tree (git status shows two modified form files; the two new files are untracked but written to disk).
- Manual smoke testing in a browser has not been performed.
Relevant files / directories
Created:
- src/app/api/uploadthing-cleanup/route.ts — admin-only POST cleanup endpoint
- src/lib/uploadthing/cleanup.ts — client-safe helper requestUploadThingFileDeletion
- ~/Desktop/issue-92-fix-summary.md — initial fix summary (out of date vs final implementation)
Modified:
- src/components/dashboard/featured-listings/FeaturedListingForm.tsx
- src/components/dashboard/presale/PreSaleForm.tsx
Read for context (unchanged):
- src/server/uploadthing/cleanup.ts — server-only deleteUploadThingFileByUrl + extractUploadThingFileKey
- src/utils/api/route-helpers.ts — withApiHandler, parseAndValidateBody
- src/app/api/uploadthing/route.ts — existing UploadThing handler (separate path)
- src/lib/uploadthing/index.ts — existing client exports
- src/components/dashboard/featured-listings/FeaturedListingImageUpload.tsx — child upload UI
- src/components/dashboard/presale/PreSaleImageUpload.tsx — child upload UI
- src/app/api/presales/[id]/route.ts, src/app/api/presales/route.ts, src/app/api/featured-listings/[id]/route.ts, src/app/api/featured-listings/route.ts — existing server-side cleanup callers (confirmed they handle saved-state diff only)
