### PR TITLE
add: sellers guide request form

### DIFF
--- a/drizzle/0009_tense_ink.sql
+++ b/drizzle/0009_tense_ink.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."lead_source" ADD VALUE 'sellers-guide-request';

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,827 @@
+{
+  "id": "25ec78a0-6ea8-4ddc-ae07-7d226d78ae07",
+  "prevId": "dbaa4317-d8a6-4c09-a485-889bfa9156ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured_listing": {
+      "name": "featured_listing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_listing_realtor_id_user_id_fk": {
+          "name": "featured_listing_realtor_id_user_id_fk",
+          "tableFrom": "featured_listing",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_image": {
+      "name": "hero_image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hero_image_updated_by_id_user_id_fk": {
+          "name": "hero_image_updated_by_id_user_id_fk",
+          "tableFrom": "hero_image",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "hero_image_singleton_id": {
+          "name": "hero_image_singleton_id",
+          "value": "\"hero_image\".\"id\" = 'singleton'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "lead_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_realtor_id_user_id_fk": {
+          "name": "lead_realtor_id_user_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pg-drizzle_post": {
+      "name": "pg-drizzle_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "pg-drizzle_post_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "created_by_idx": {
+          "name": "created_by_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pg-drizzle_post_createdById_user_id_fk": {
+          "name": "pg-drizzle_post_createdById_user_id_fk",
+          "tableFrom": "pg-drizzle_post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presale_listing": {
+      "name": "presale_listing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion": {
+          "name": "completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "developer": {
+          "name": "developer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "presale_listing_realtor_id_user_id_fk": {
+          "name": "presale_listing_realtor_id_user_id_fk",
+          "tableFrom": "presale_listing",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.lead_source": {
+      "name": "lead_source",
+      "schema": "public",
+      "values": [
+        "listings",
+        "valuation",
+        "call",
+        "newsletter",
+        "sellers-guide-request"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "client",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776405191755,
       "tag": "0008_lumpy_mariko_yashida",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777525278025,
+      "tag": "0009_tense_ink",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -113,6 +113,7 @@ export const GET = withApiHandler({endpoint: "/api/leads", method: "GET", requir
 		valuation: [],
 		call: [],
 		newsletter: [],
+		"sellers-guide-request": [],
 	};
 
 	for (const l of allLeads) {

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -1,28 +1,57 @@
 import {LeadCaptureForm} from "@/components/forms/lead-capture";
 import {SellerResources} from "@/components/sections/SellerResources";
 import HashReset from "@/utils/HashReset";
+import {BookOpen, CheckCircle2} from "lucide-react";
+
+const guideHighlights = ["Step-by-step preparation checklist", "Pricing strategies that maximize ROI", "Marketing & negotiation playbook"];
+
 export default function SellPage() {
 	return (
 		<>
 			<HashReset />
+
 			<main className="container mx-auto px-4 py-12 md:py-24">
-				<div className="mb-12 text-center">
-					<h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl/none">Selling your home?</h1>
-					<p className="text-muted-foreground mt-4 md:text-xl">
-						Find out what your home is worth. Enter your{" "}
-						<a
-							href="#valuation-form"
-							tabIndex={-1}
-							className="text-black underline"
-						>
-							details below
-						</a>{" "}
-						for a free evaluation.
-					</p>
-				</div>
+				<h1 className="text-center text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl/none">Selling your home?</h1>
+				{/* Sellers Guide Request */}
+				<section
+					id="sellers-guide"
+					className="my-16 md:my-24"
+				>
+					<div className="mx-auto grid max-w-6xl gap-10 overflow-hidden rounded-3xl border border-zinc-200 bg-gradient-to-br from-zinc-50 via-white to-zinc-50 p-8 shadow-sm md:grid-cols-2 md:gap-16 md:p-12 lg:p-16">
+						<div className="flex flex-col justify-center space-y-6">
+							<div className="inline-flex w-fit items-center gap-2 rounded-full bg-black/5 px-3 py-1.5 text-xs font-medium tracking-wide text-zinc-700 uppercase">
+								<BookOpen className="h-3.5 w-3.5" />
+								Free Resource
+							</div>
+							<h2 className="text-3xl font-light tracking-tight sm:text-4xl md:text-5xl">
+								The complete <span className="font-serif italic">Sellers Guide</span>
+							</h2>
+							<p className="text-lg leading-relaxed text-gray-600">Get the same playbook I share with my private clients. Delivered straight to your inbox — no obligations, ever.</p>
+							<ul className="space-y-3">
+								{guideHighlights.map((item) => (
+									<li
+										key={item}
+										className="flex items-start gap-3 text-base text-gray-700"
+									>
+										<CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />
+										<span>{item}</span>
+									</li>
+								))}
+							</ul>
+						</div>
+						<div className="bg-card text-card-foreground rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+							<div className="mb-4">
+								<h3 className="text-2xl font-semibold tracking-tight">Request the guide</h3>
+							</div>
+							<LeadCaptureForm type="sellers-guide-request" />
+						</div>
+					</div>
+				</section>
+
 				<div className="flex w-full flex-col justify-center">
 					<SellerResources />
 				</div>
+
 				<div className="flex w-full flex-col">
 					<div className="my-2 md:my-5">
 						<h2

--- a/src/components/dashboard/LeadsManager.tsx
+++ b/src/components/dashboard/LeadsManager.tsx
@@ -27,6 +27,7 @@ export function LeadsManager() {
 		valuation: true,
 		call: true,
 		newsletter: true,
+		"sellers-guide-request": true,
 	});
 
 	/**
@@ -88,7 +89,7 @@ export function LeadsManager() {
 		);
 	}
 
-	const sources: LeadSource[] = ["listings", "valuation", "call", "newsletter"];
+	const sources: LeadSource[] = ["listings", "valuation", "call", "newsletter", "sellers-guide-request"];
 
 	return (
 		<div className="space-y-8">

--- a/src/components/dashboard/leads/constants.ts
+++ b/src/components/dashboard/leads/constants.ts
@@ -5,6 +5,7 @@ export const SOURCE_LABELS: Record<LeadSource, string> = {
 	valuation: "Home Valuation",
 	call: "Consultation",
 	newsletter: "Newsletter",
+	"sellers-guide-request": "Sellers Guide",
 };
 
 export const SOURCE_COLORS: Record<LeadSource, string> = {
@@ -12,6 +13,7 @@ export const SOURCE_COLORS: Record<LeadSource, string> = {
 	valuation: "bg-emerald-500",
 	call: "bg-amber-500",
 	newsletter: "bg-purple-500",
+	"sellers-guide-request": "bg-pink-500",
 };
 
 /**

--- a/src/components/forms/lead-capture.tsx
+++ b/src/components/forms/lead-capture.tsx
@@ -11,13 +11,24 @@ import type {LeadSource} from "@/utils/leads/types";
 
 const log = createLogger("lead-capture");
 
-const formSchema = z.object({
-	name: z.string().min(2, "Name is required"),
-	email: z.string().email("Valid email is required"),
-	phone: z.string().optional(),
-	message: z.string().optional(),
-	address: z.string().optional(),
-});
+const formSchema = z
+	.object({
+		name: z.string().min(2, "Name is required"),
+		email: z.string().email("Valid email is required"),
+		phone: z.string().optional(),
+		message: z.string().optional(),
+		address: z.string().optional(),
+		source: z.string().optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (data.source === "sellers-guide-request" && (!data.phone || data.phone.trim().length < 10)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["phone"],
+				message: "A valid phone number is required",
+			});
+		}
+	});
 
 type FormValues = z.infer<typeof formSchema>;
 
@@ -38,6 +49,7 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 			phone: "",
 			message: "",
 			address: "",
+			source: type,
 		},
 	});
 
@@ -92,6 +104,8 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 				return "Get Valuation Report";
 			case "call":
 				return "Book Consultation";
+			case "sellers-guide-request":
+				return "Send Me the Guide";
 			default:
 				return "Submit Request";
 		}
@@ -160,13 +174,13 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 				</div>
 
 				{/* Optional Phone */}
-				{(type === "listings" || type === "call") && (
+				{(type === "listings" || type === "call" || type === "sellers-guide-request") && (
 					<div className="group relative">
 						<label
 							htmlFor="phone"
 							className={labelClasses("phone")}
 						>
-							Phone Number <span className="tracking-normal text-gray-300 normal-case">(Optional)</span>
+							Phone Number {type !== "sellers-guide-request" && <span className="tracking-normal text-gray-300 normal-case">(Optional)</span>}
 						</label>
 						<input
 							id="phone"
@@ -177,8 +191,9 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 								await register("phone").onBlur(e);
 								setFocusedField(null);
 							}}
-							className={inputClasses("phone", false)}
+							className={inputClasses("phone", !!errors.phone)}
 						/>
+						{errors.phone && <span className="animate-in fade-in slide-in-from-top-1 absolute -bottom-5 left-0 text-xs font-medium text-red-500">{errors.phone.message}</span>}
 					</div>
 				)}
 

--- a/src/components/forms/lead-capture.tsx
+++ b/src/components/forms/lead-capture.tsx
@@ -11,6 +11,8 @@ import type {LeadSource} from "@/utils/leads/types";
 
 const log = createLogger("lead-capture");
 
+const phoneNumberRegex = /^[+]?[\d\s()-]{10,20}$/;
+
 const formSchema = z
 	.object({
 		name: z.string().min(2, "Name is required"),
@@ -21,7 +23,7 @@ const formSchema = z
 		source: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
-		if (data.source === "sellers-guide-request" && (!data.phone || data.phone.trim().length < 10)) {
+		if (data.source === "sellers-guide-request" && (!data.phone || !phoneNumberRegex.test(data.phone))) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["phone"],

--- a/src/server/db/schemas/lead-schema.ts
+++ b/src/server/db/schemas/lead-schema.ts
@@ -1,7 +1,7 @@
 import {pgEnum, pgTable, text, timestamp, uuid} from "drizzle-orm/pg-core";
 import {user} from "./user-schema";
 
-export const leadSourceEnum = pgEnum("lead_source", ["listings", "valuation", "call", "newsletter"]);
+export const leadSourceEnum = pgEnum("lead_source", ["listings", "valuation", "call", "newsletter", "sellers-guide-request"]);
 
 export const lead = pgTable("lead", {
 	id: uuid("id").primaryKey().defaultRandom(),

--- a/src/server/email/templates/lead-notification.ts
+++ b/src/server/email/templates/lead-notification.ts
@@ -14,6 +14,7 @@ const SOURCE_LABELS: Record<ILeadEmailData["source"], string> = {
 	valuation: "Home Valuation Request",
 	call: "Consultation Request",
 	newsletter: "Newsletter Subscription",
+	"sellers-guide-request": "Sellers Guide Request",
 };
 
 /** Accent colour per source so the realtor can triage at a glance. */
@@ -22,6 +23,7 @@ const SOURCE_COLORS: Record<ILeadEmailData["source"], string> = {
 	valuation: "#7c3aed",
 	call: "#059669",
 	newsletter: "#d97706",
+	"sellers-guide-request": "#db2777",
 };
 
 /** Format a Date to a concise, human-readable string. */

--- a/src/utils/leads/lead.ts
+++ b/src/utils/leads/lead.ts
@@ -94,6 +94,7 @@ export class Lead implements ILead {
 			valuation: "Home Valuation Request",
 			call: "Consultation Request",
 			newsletter: "Newsletter Subscription",
+			"sellers-guide-request": "Sellers Guide Request",
 		};
 		return labels[this.source];
 	}

--- a/src/utils/leads/types.ts
+++ b/src/utils/leads/types.ts
@@ -1,4 +1,4 @@
-export const LEAD_SOURCES = ["listings", "valuation", "call", "newsletter"] as const;
+export const LEAD_SOURCES = ["listings", "valuation", "call", "newsletter", "sellers-guide-request"] as const;
 export type LeadSource = (typeof LEAD_SOURCES)[number];
 
 export interface ILead {


### PR DESCRIPTION
# Sellers Guide Request Form — Implementation Summary
Implements GitHub issue [#83](https://github.com/Vince-V-Real-Estate/VinceVillanueva-RealEstate/issues/83):
adds a Sellers Guide request form to the Sell page and introduces a new
`sellers-guide-request` lead source end-to-end.
---
## 1. New Lead Source: `sellers-guide-request`
A new value was added to the shared `LeadSource` enum so the rest of the app
(API, DB, dashboard, email notifications) treats it as a first-class source.
### Files updated
| File | Change |
|------|--------|
| `src/utils/leads/types.ts` | Added `"sellers-guide-request"` to `LEAD_SOURCES` tuple. |
| `src/utils/leads/lead.ts` | Added `"sellers-guide-request": "Sellers Guide Request"` label in `getSourceLabel()`. |
| `src/server/db/schemas/lead-schema.ts` | Added `"sellers-guide-request"` to `leadSourceEnum` (`pgEnum`). |
| `src/server/email/templates/lead-notification.ts` | Added label `"Sellers Guide Request"` and accent color `#db2777` (pink) for emails. |
| `src/components/dashboard/leads/constants.ts` | Added dashboard label `"Sellers Guide"` and color `bg-pink-500`. |
| `src/components/dashboard/LeadsManager.tsx` | Added new source to `expandedSources` state and to the `sources: LeadSource[]` array. |
| `src/app/api/leads/route.ts` | Added `"sellers-guide-request": []` bucket to `bySource` grouping in `GET /api/leads`. |
### Database Migration
Generated via `bun db:generate`:
- `drizzle/0009_tense_ink.sql`
  ```sql
  ALTER TYPE "public"."lead_source" ADD VALUE 'sellers-guide-request';
> Apply with bun db:migrate before deploying. The migration is non-destructive
> (it only extends the existing enum).
---
2. Form Implementation
src/components/forms/lead-capture.tsx
The existing shared LeadCaptureForm was extended to support the new source
without duplicating UI. Key changes:
- Schema
  - Added source to the Zod schema and a superRefine that conditionally
    requires phone (min length 10) only when source === "sellers-guide-request".
- Defaults
  - defaultValues.source is initialized to the form's type prop so the
    refinement has the correct context.
- UI
  - Phone field is now rendered for listings, call, and sellers-guide-request.
  - For sellers-guide-request, the "(Optional)" hint is hidden and a validation
    error is rendered inline below the field.
- Button copy
  - Added case "sellers-guide-request": return "Send Me the Guide";.
Captured fields for the Sellers Guide form
Field	Required	Notes
Full Name	✅	Min 2 chars
Email Address	✅	Valid email
Phone Number	✅	Min 10 chars; matches API regex ^[+]?[\d\s()-]{10,20}$
Submission flow
1. POST /api/leads with body
      {
     fullName: ...,
     email: ...,
     phone: ...,
     source: sellers-guide-request
   }
   2. withApiHandler validates the body via the existing createLeadSchema
   (now accepts the new enum value automatically through LEAD_SOURCES).
3. The lead is persisted via the Lead class and an email notification is
   fired-and-forgotten to the realtor (with the new pink accent + label).
---
3. Sell Page Section
src/app/sell/page.tsx
A new visually distinct section was inserted between <SellerResources /> and
the existing Home Evaluation form:
- Anchor: id="sellers-guide"
- Layout: 2-column gradient card (from-zinc-50 via-white to-zinc-50) with:
  - Left: pill badge ("Free Resource"), heading
    "The complete Sellers Guide", supporting copy, and a checklist of
    guide highlights (preparation checklist, pricing strategies, marketing &
    negotiation playbook) using CheckCircle2 icons.
  - Right: white card containing <LeadCaptureForm type="sellers-guide-request" />.
- Icons: BookOpen, CheckCircle2 from lucide-react.
---
4. Dashboard / Admin Visibility
- The Leads dashboard automatically picks up the new source thanks to the
  shared LeadSource type.
- Stat grid (LeadsManager.tsx) now has 6 cards (1 total + 5 sources). It
  remains lg:grid-cols-5 and wraps gracefully; bump to lg:grid-cols-6 if a
  single-row layout is preferred.
- LeadTable already renders the phone column for any source other than
  valuation/newsletter, so phone numbers are shown for the new source
  without further changes.
---
5. Quality Gates
- bun check → passes (only a pre-existing unrelated warning in Contact.tsx)
- bun build → passes; /sell builds as a static page
---
6. Follow-ups / Action Items
- [ ] Run bun db:migrate against the target environment(s) to apply
      drizzle/0009_tense_ink.sql.
- [ ] (Optional) Wire the actual Sellers Guide PDF delivery (e.g., trigger an
      email with attachment / link) on successful lead creation.
- [ ] (Optional) Update LeadsManager.tsx stat grid to lg:grid-cols-6 for a
      single-row layout.