### PR TITLE
Dev

### DIFF
--- a/drizzle/0010_flippant_falcon.sql
+++ b/drizzle/0010_flippant_falcon.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."lead_source" ADD VALUE 'buyers-guide-request';

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,828 @@
+{
+  "id": "b5dff62f-a0bb-403e-b5e0-505eea20b7cc",
+  "prevId": "25ec78a0-6ea8-4ddc-ae07-7d226d78ae07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured_listing": {
+      "name": "featured_listing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_listing_realtor_id_user_id_fk": {
+          "name": "featured_listing_realtor_id_user_id_fk",
+          "tableFrom": "featured_listing",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_image": {
+      "name": "hero_image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hero_image_updated_by_id_user_id_fk": {
+          "name": "hero_image_updated_by_id_user_id_fk",
+          "tableFrom": "hero_image",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "hero_image_singleton_id": {
+          "name": "hero_image_singleton_id",
+          "value": "\"hero_image\".\"id\" = 'singleton'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lead": {
+      "name": "lead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "lead_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_realtor_id_user_id_fk": {
+          "name": "lead_realtor_id_user_id_fk",
+          "tableFrom": "lead",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pg-drizzle_post": {
+      "name": "pg-drizzle_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "pg-drizzle_post_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "created_by_idx": {
+          "name": "created_by_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pg-drizzle_post_createdById_user_id_fk": {
+          "name": "pg-drizzle_post_createdById_user_id_fk",
+          "tableFrom": "pg-drizzle_post",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presale_listing": {
+      "name": "presale_listing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion": {
+          "name": "completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "developer": {
+          "name": "developer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realtor_id": {
+          "name": "realtor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "presale_listing_realtor_id_user_id_fk": {
+          "name": "presale_listing_realtor_id_user_id_fk",
+          "tableFrom": "presale_listing",
+          "tableTo": "user",
+          "columnsFrom": [
+            "realtor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.lead_source": {
+      "name": "lead_source",
+      "schema": "public",
+      "values": [
+        "listings",
+        "valuation",
+        "call",
+        "newsletter",
+        "sellers-guide-request",
+        "buyers-guide-request"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "client",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777525278025,
       "tag": "0009_tense_ink",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777615176403,
+      "tag": "0010_flippant_falcon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -110,6 +110,7 @@ export const GET = withApiHandler({endpoint: "/api/leads", method: "GET", requir
 		call: [],
 		newsletter: [],
 		"sellers-guide-request": [],
+		"buyers-guide-request": [],
 	};
 
 	for (const l of allLeads) {

--- a/src/app/buy/page.tsx
+++ b/src/app/buy/page.tsx
@@ -1,8 +1,51 @@
+import {LeadCaptureForm} from "@/components/forms/lead-capture";
+import HashReset from "@/utils/HashReset";
+import {BookOpen, CheckCircle2} from "lucide-react";
+
+const guideHighlights = ["Mortgage pre-approval roadmap", "Neighborhood & inspection checklist", "Offer & negotiation tactics"];
+
 export default function BuyPage() {
 	return (
 		<>
-			<main>
-				<h1>Buy page</h1>
+			<HashReset />
+
+			<main className="container mx-auto px-4 py-12 md:py-24">
+				<h1 className="text-center text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl/none">Buying your home?</h1>
+				{/* Buyers Guide Request */}
+				<section
+					id="buyers-guide"
+					className="my-16 md:my-24"
+				>
+					<div className="mx-auto grid max-w-6xl gap-10 overflow-hidden rounded-3xl border border-zinc-200 bg-gradient-to-br from-zinc-50 via-white to-zinc-50 p-8 shadow-sm md:grid-cols-2 md:gap-16 md:p-12 lg:p-16">
+						<div className="flex flex-col justify-center space-y-6">
+							<div className="inline-flex w-fit items-center gap-2 rounded-full bg-black/5 px-3 py-1.5 text-xs font-medium tracking-wide text-zinc-700 uppercase">
+								<BookOpen className="h-3.5 w-3.5" />
+								Free Resource
+							</div>
+							<h2 className="text-3xl font-light tracking-tight sm:text-4xl md:text-5xl">
+								The complete <span className="font-serif italic">Buyers Guide</span>
+							</h2>
+							<p className="text-lg leading-relaxed text-gray-600">Everything you need to navigate the market with confidence. Delivered straight to your inbox — no obligations, ever.</p>
+							<ul className="space-y-3">
+								{guideHighlights.map((item) => (
+									<li
+										key={item}
+										className="flex items-start gap-3 text-base text-gray-700"
+									>
+										<CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />
+										<span>{item}</span>
+									</li>
+								))}
+							</ul>
+						</div>
+						<div className="bg-card text-card-foreground rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+							<div className="mb-4">
+								<h3 className="text-2xl font-semibold tracking-tight">Request the guide</h3>
+							</div>
+							<LeadCaptureForm type="buyers-guide-request" />
+						</div>
+					</div>
+				</section>
 			</main>
 		</>
 	);

--- a/src/components/dashboard/LeadsManager.tsx
+++ b/src/components/dashboard/LeadsManager.tsx
@@ -28,6 +28,7 @@ export function LeadsManager() {
 		call: true,
 		newsletter: true,
 		"sellers-guide-request": true,
+		"buyers-guide-request": true,
 	});
 
 	/**
@@ -89,7 +90,7 @@ export function LeadsManager() {
 		);
 	}
 
-	const sources: LeadSource[] = ["listings", "valuation", "call", "newsletter", "sellers-guide-request"];
+	const sources: LeadSource[] = ["listings", "valuation", "call", "newsletter", "sellers-guide-request", "buyers-guide-request"];
 
 	return (
 		<div className="space-y-8">

--- a/src/components/dashboard/leads/constants.ts
+++ b/src/components/dashboard/leads/constants.ts
@@ -6,6 +6,7 @@ export const SOURCE_LABELS: Record<LeadSource, string> = {
 	call: "Consultation",
 	newsletter: "Newsletter",
 	"sellers-guide-request": "Sellers Guide",
+	"buyers-guide-request": "Buyers Guide",
 };
 
 export const SOURCE_COLORS: Record<LeadSource, string> = {
@@ -14,6 +15,7 @@ export const SOURCE_COLORS: Record<LeadSource, string> = {
 	call: "bg-amber-500",
 	newsletter: "bg-purple-500",
 	"sellers-guide-request": "bg-pink-500",
+	"buyers-guide-request": "bg-cyan-500",
 };
 
 /**

--- a/src/components/forms/lead-capture.tsx
+++ b/src/components/forms/lead-capture.tsx
@@ -21,7 +21,7 @@ const formSchema = z
 		source: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
-		if ((data.source === "sellers-guide-request" || data.source === "buyers-guide-request") && !data.phone) {
+		if ((data.source === "sellers-guide-request" || data.source === "buyers-guide-request") && !data?.phone?.trim()) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["phone"],

--- a/src/components/forms/lead-capture.tsx
+++ b/src/components/forms/lead-capture.tsx
@@ -21,7 +21,7 @@ const formSchema = z
 		source: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
-		if (data.source === "sellers-guide-request" && (!data.phone || !PHONE_NUMBER_REGEX.test(data.phone))) {
+		if ((data.source === "sellers-guide-request" || data.source === "buyers-guide-request") && (!data.phone || !PHONE_NUMBER_REGEX.test(data.phone))) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["phone"],
@@ -105,6 +105,7 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 			case "call":
 				return "Book Consultation";
 			case "sellers-guide-request":
+			case "buyers-guide-request":
 				return "Send Me the Guide";
 			default:
 				return "Submit Request";
@@ -174,13 +175,13 @@ export function LeadCaptureForm({type, className, onSuccess}: LeadCaptureFormPro
 				</div>
 
 				{/* Optional Phone */}
-				{(type === "listings" || type === "call" || type === "sellers-guide-request") && (
+				{(type === "listings" || type === "call" || type === "sellers-guide-request" || type === "buyers-guide-request") && (
 					<div className="group relative">
 						<label
 							htmlFor="phone"
 							className={labelClasses("phone")}
 						>
-							Phone Number {type !== "sellers-guide-request" && <span className="tracking-normal text-gray-300 normal-case">(Optional)</span>}
+							Phone Number {type !== "sellers-guide-request" && type !== "buyers-guide-request" && <span className="tracking-normal text-gray-300 normal-case">(Optional)</span>}
 						</label>
 						<input
 							id="phone"

--- a/src/components/forms/lead-capture.tsx
+++ b/src/components/forms/lead-capture.tsx
@@ -21,7 +21,7 @@ const formSchema = z
 		source: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
-		if ((data.source === "sellers-guide-request" || data.source === "buyers-guide-request") && (!data.phone || !PHONE_NUMBER_REGEX.test(data.phone))) {
+		if ((data.source === "sellers-guide-request" || data.source === "buyers-guide-request") && !data.phone) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["phone"],

--- a/src/server/db/schemas/lead-schema.ts
+++ b/src/server/db/schemas/lead-schema.ts
@@ -1,7 +1,7 @@
 import {pgEnum, pgTable, text, timestamp, uuid} from "drizzle-orm/pg-core";
 import {user} from "./user-schema";
 
-export const leadSourceEnum = pgEnum("lead_source", ["listings", "valuation", "call", "newsletter", "sellers-guide-request"]);
+export const leadSourceEnum = pgEnum("lead_source", ["listings", "valuation", "call", "newsletter", "sellers-guide-request", "buyers-guide-request"]);
 
 export const lead = pgTable("lead", {
 	id: uuid("id").primaryKey().defaultRandom(),

--- a/src/server/email/templates/lead-notification.ts
+++ b/src/server/email/templates/lead-notification.ts
@@ -15,6 +15,7 @@ const SOURCE_LABELS: Record<ILeadEmailData["source"], string> = {
 	call: "Consultation Request",
 	newsletter: "Newsletter Subscription",
 	"sellers-guide-request": "Sellers Guide Request",
+	"buyers-guide-request": "Buyers Guide Request",
 };
 
 /** Accent colour per source so the realtor can triage at a glance. */
@@ -24,6 +25,7 @@ const SOURCE_COLORS: Record<ILeadEmailData["source"], string> = {
 	call: "#059669",
 	newsletter: "#d97706",
 	"sellers-guide-request": "#db2777",
+	"buyers-guide-request": "#0891b2",
 };
 
 /** Format a Date to a concise, human-readable string. */

--- a/src/utils/leads/lead.ts
+++ b/src/utils/leads/lead.ts
@@ -95,6 +95,7 @@ export class Lead implements ILead {
 			call: "Consultation Request",
 			newsletter: "Newsletter Subscription",
 			"sellers-guide-request": "Sellers Guide Request",
+			"buyers-guide-request": "Buyers Guide Request",
 		};
 		return labels[this.source];
 	}

--- a/src/utils/leads/types.ts
+++ b/src/utils/leads/types.ts
@@ -1,4 +1,4 @@
-export const LEAD_SOURCES = ["listings", "valuation", "call", "newsletter", "sellers-guide-request"] as const;
+export const LEAD_SOURCES = ["listings", "valuation", "call", "newsletter", "sellers-guide-request", "buyers-guide-request"] as const;
 export type LeadSource = (typeof LEAD_SOURCES)[number];
 
 /**


### PR DESCRIPTION
This pull request adds support for a new lead source: "buyers-guide-request". The changes ensure that the new lead source is fully integrated across the backend, API, form validation, dashboard, and email notification systems. This allows users to request a Buyers Guide, and for these leads to be properly captured, displayed, and managed throughout the application.

**Lead Source Integration**

* Added "buyers-guide-request" to the `lead_source` enum in both the database schema and Drizzle ORM types, ensuring backend compatibility. [[1]](diffhunk://#diff-3794ef33ffa7081385d500eddc6aa86f7bcf944774852730d8f2eb1b8d41d2f2R1) [[2]](diffhunk://#diff-c777c5ba5d6892c99de757b7f5220968a42edae8489a4baae3088309b68e60e6L4-R4) [[3]](diffhunk://#diff-dae5b2e19779de17a0d8500612d653cf52430826f42de957094b1338eca8a636L1-R1)
* Updated API route logic and dashboard code to recognize and handle "buyers-guide-request" leads, including filtering and display. [[1]](diffhunk://#diff-6837c7bf9abd211217ba014e9145f3c067e2498786f6a49201988a9e4e16c0e4R113) [[2]](diffhunk://#diff-84cf74e586b6f21049fe9795298be2c2c6726d614b72ee70920eaf96c0f77939R31) [[3]](diffhunk://#diff-84cf74e586b6f21049fe9795298be2c2c6726d614b72ee70920eaf96c0f77939L92-R93)

**Form and Validation Updates**

* Modified the `LeadCaptureForm` to support "buyers-guide-request", including requiring a phone number for this lead type and updating form labels and submit button text accordingly. [[1]](diffhunk://#diff-634282fb3c30ae86e20edfeef77f5d6bd84c2ad5b699244fcd9364499f9106f0L24-R24) [[2]](diffhunk://#diff-634282fb3c30ae86e20edfeef77f5d6bd84c2ad5b699244fcd9364499f9106f0R108) [[3]](diffhunk://#diff-634282fb3c30ae86e20edfeef77f5d6bd84c2ad5b699244fcd9364499f9106f0L177-R184) [[4]](diffhunk://#diff-cbc7b61b86daa5cc3263df5e01c390b8a052c461fe924e325162016ed399888fR1-R48)

**UI and Label Enhancements**

* Added user-facing labels and colors for "buyers-guide-request" across the dashboard, email templates, and utility classes, ensuring consistent presentation and triage. [[1]](diffhunk://#diff-bc9e0b99bfa786364ddfed2bd402dff244858d4626b4535b5834bf73f9e4c7c4R9) [[2]](diffhunk://#diff-bc9e0b99bfa786364ddfed2bd402dff244858d4626b4535b5834bf73f9e4c7c4R18) [[3]](diffhunk://#diff-911fb0990a9c5b1eedc0eafdee31c2b9fe0afc496b388780484ebba55157ec61R18) [[4]](diffhunk://#diff-911fb0990a9c5b1eedc0eafdee31c2b9fe0afc496b388780484ebba55157ec61R28) [[5]](diffhunk://#diff-ca0074a894432f8f8e2b251b1b6fc0b54f08599245cd26c05b2743f99a0962ecR98)

**Database Migration**

* Introduced a new migration file to add the "buyers-guide-request" value to the `lead_source` enum in the database. [[1]](diffhunk://#diff-3794ef33ffa7081385d500eddc6aa86f7bcf944774852730d8f2eb1b8d41d2f2R1) [[2]](diffhunk://#diff-349e2e5efe6c282645244197ec3a36bee4f6fbc9988ee5acc46a05603f6829cdR74-R80)